### PR TITLE
update docs to reference restart_process extension instead of restart_container live update step when possible [ch5945]

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -66,9 +66,16 @@ def run(cmd: str, trigger: Union[List[str], str] = []) -> LiveUpdateStep:
   pass
 
 def restart_container() -> LiveUpdateStep:
-  """Specify that a container should be restarted when it is live-updated.
+  """Specify that a container should be restarted when it is live-updated. In
+  practice, this means that the container re-executes its `ENTRYPOINT` within
+  the changed filesystem.
 
   May only be included in a `live_update` once, and only as the last step.
+
+  NOTE: this function will soon be deprecated. If you want to restart a Docker-built
+  image running on Kubernetes, use the `restart_process extension <https://github.com/windmilleng/tilt-extensions/tree/master/restart_process>`_.
+  At the moment, ``restart_container`` should only be used in conjunction
+  with ``custom_build`` or for images run by Docker Compose.
 
   Only works on containers managed by Docker. For non-Docker runtimes
   (e.g. containerd, CRI-O), please see the `wrapper script for simulating

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -5411,7 +5411,13 @@ In any other case, an error reading
           </dt>
           <dd>
            <p>
-            Specify that a container should be restarted when it is live-updated.
+            Specify that a container should be restarted when it is live-updated. In
+practice, this means that the container re-executes its
+            <cite>
+             ENTRYPOINT
+            </cite>
+            within
+the changed filesystem.
            </p>
            <p>
             May only be included in a
@@ -5419,6 +5425,28 @@ In any other case, an error reading
              live_update
             </cite>
             once, and only as the last step.
+           </p>
+           <p>
+            NOTE: this function will soon be deprecated. If you want to restart a Docker-built
+image running on Kubernetes, use the
+            <a class="reference external" href="https://github.com/windmilleng/tilt-extensions/tree/master/restart_process">
+             restart_process extension
+            </a>
+            .
+At the moment,
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              restart_container
+             </span>
+            </code>
+            should only be used in conjunction
+with
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              custom_build
+             </span>
+            </code>
+            or for images run by Docker Compose.
            </p>
            <p>
             Only works on containers managed by Docker. For non-Docker runtimes


### PR DESCRIPTION
this is necessarily kind of ugly b/c this extension should only be
used SOMETIMES :-/

this seemed like an okay first pass? next i'll revise the live_update tutorial