### PR TITLE
guides: update guides to reflect restart_process extension instead of entr hack for restarting

### DIFF
--- a/docs/example_csharp.md
+++ b/docs/example_csharp.md
@@ -223,9 +223,9 @@ The first thing to notice is the `live_update` parameter, which consists of one 
 This copies the build output from the `out` directory into the container.
 
 After syncing the files, we want to re-execute our updated binary. We accomplish this with the
-[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process)
-(for more on extensions, [see the docs](/extensions.html)).
-In particular, we swap out our `docker_build` call for a `docker_build_with_restart` call; it's
+[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process),
+which we imported with the `load` call on the first line. (For more on extensions, [see the docs](/extensions.html).)
+We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
 

--- a/docs/example_csharp.md
+++ b/docs/example_csharp.md
@@ -206,23 +206,28 @@ With Tilt, we can skip all of these steps, and instead [live_update](live_update
 Here's our [new Tiltfile](https://github.com/tilt-dev/tilt-example-csharp/blob/master/3-live-update/Tiltfile) with the following new code:
 
 ```python
-docker_build(
+load('ext://restart_process', 'docker_build_with_restart')
+...
+docker_build_with_restart(
     'hello-tilt',
     'out',
+    entrypoint=['dotnet', 'hello-tilt.dll'],
     dockerfile='Dockerfile',
     live_update=[
         sync('out', '/app/out'),
     ],
-    entrypoint='find . | entr -r dotnet hello-tilt.dll',
 )
 ```
 
-We've added a `live_update` parameter to `docker_build()` with a `sync` step. This copies the build output from the `out` directory into container.
+The first thing to notice is the `live_update` parameter, which consists of one `sync` step.
+This copies the build output from the `out` directory into the container.
 
-We've also added a new parameter: `entrypoint='find . | entr -r dotnet hello-tilt.dll'`.
-
-`entr` is a tool that automatically restarts a shell command whenever the watched
-file changes. This command restarts our server every time the pod is updated.
+After syncing the files, we want to re-execute our updated binary. We accomplish this with the
+[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process)
+(for more on extensions, [see the docs](/extensions.html)).
+In particular, we swap out our `docker_build` call for a `docker_build_with_restart` call; it's
+almost exactly the same as `docker_build`, only it knows to restart our process at the end
+of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
 
 Let's see what this new configuration looks like in action:
 

--- a/docs/example_go.md
+++ b/docs/example_go.md
@@ -246,9 +246,9 @@ The first thing to notice is the `live_update` parameter, which consists of two 
 steps. They copy the code from the `./build` and `./web` directories into the container.
 
 After syncing the files, we want to re-execute our updated binary. We accomplish this with the
-[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process)
-(for more on extensions, [see the docs](/extensions.html)).
-In particular, we swap out our `docker_build` call for a `docker_build_with_restart` call; it's
+[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process),
+which we imported with the `load` call on the first line. (For more on extensions, [see the docs](/extensions.html).)
+We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
 

--- a/docs/example_go.md
+++ b/docs/example_go.md
@@ -224,9 +224,12 @@ Here's our [new Tiltfile](https://github.com/tilt-dev/tilt-example-go/blob/maste
 with the following new code:
 
 ```python
-docker_build(
+load('ext://restart_process', 'docker_build_with_restart')
+...
+docker_build_with_restart(
   'example-go-image',
   '.',
+  entrypoint='/app/build/tilt-example-go',
   dockerfile='deployments/Dockerfile',
   only=[
     './build',
@@ -236,16 +239,18 @@ docker_build(
     sync('./build', '/app/build'),
     sync('./web', '/app/web'),
   ],
-  entrypoint = 'find . | entr -r ./build/tilt-example-go')
+)
 ```
 
-We've added a `live_update` parameter to `docker_build()` with two `sync` steps.
-They copy the code from the `./build` and `./web` directories into the container.
+The first thing to notice is the `live_update` parameter, which consists of two `sync`
+steps. They copy the code from the `./build` and `./web` directories into the container.
 
-We've also added a new parameter: `entrypoint="find . | entr -r ./build/tilt-example-go"`.
-
-`entr` is a tool that automatically restarts a shell command whenever the watched
-file changes. This command restarts our server every time the pod is updated.
+After syncing the files, we want to re-execute our updated binary. We accomplish this with the
+[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process)
+(for more on extensions, [see the docs](/extensions.html)).
+In particular, we swap out our `docker_build` call for a `docker_build_with_restart` call; it's
+almost exactly the same as `docker_build`, only it knows to restart our process at the end
+of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
 
 Let's see what this new configuration looks like in action:
 

--- a/docs/example_java.md
+++ b/docs/example_java.md
@@ -322,9 +322,9 @@ They copy the library and compiled `.class `files from the `./build/jar`
 directory into the container.
 
 After syncing the files, we want to re-execute our updated binary. We accomplish this with the
-[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process)
-(for more on extensions, [see the docs](/extensions.html)).
-In particular, we swap out our `docker_build` call for a `docker_build_with_restart` call; it's
+[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process),
+which we imported with the `load` call on the first line. (For more on extensions, [see the docs](/extensions.html).)
+We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
 


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/update-ex-guides-restart_process:

061cf97b5ea118d27de643a7f832360c3815d77e (2020-05-15 19:22:23 -0400)
guides: update guides to reflect restart_process extension instead of entr hack for restarting

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics