### PR TITLE
site: fix subtle hover effect for the Tilt logo

### DIFF
--- a/src/_sass/header2.scss
+++ b/src/_sass/header2.scss
@@ -16,15 +16,20 @@ body.is-header2 .siteHeader2 {
 
 .siteHeader2-logoLink {
   opacity: 1;
-  transition: transform $anim-duration ease-in-out, 
-    opacity $anim-duration-short ease;
+  transition: opacity $anim-duration-short ease;
 
   &:hover {
     background-color: transparent;
-    transform: scale(1.025);
   }
   &:active {
     opacity: 0.8;
+  }
+}
+.siteHeader2-logoLink-svg {
+    transition: transform $anim-duration ease-in-out;
+
+  .siteHeader2-logoLink:hover & {
+    transform: scale(1.05);
   }
 }
 


### PR DESCRIPTION
It scales up a bit. Wasn't working properly because of mis-applied CSS.