### PR TITLE
site: nowrap for `tilt up` on landing page for mobile

### DIFF
--- a/src/_sass/home2.scss
+++ b/src/_sass/home2.scss
@@ -74,6 +74,7 @@
   padding-left: $spacing-unit / 4;
   padding-right: $spacing-unit / 4;
   line-height: 1;
+  white-space: nowrap;
 }
 
 .Home2-heroIllustration {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="408" alt="Screen Shot 2020-06-03 at 2 26 00 PM" src="https://user-images.githubusercontent.com/10860550/83675850-b7ccdf80-a5a7-11ea-9e81-25d61536cfd9.png"> | <img width="406" alt="Screen Shot 2020-06-03 at 2 25 29 PM" src="https://user-images.githubusercontent.com/10860550/83675849-b7ccdf80-a5a7-11ea-90cd-06c052d00375.png"> |