### PR TITLE
api: restart_container for docker compose only, add links

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -66,22 +66,16 @@ def run(cmd: str, trigger: Union[List[str], str] = []) -> LiveUpdateStep:
   pass
 
 def restart_container() -> LiveUpdateStep:
-  """Specify that a container should be restarted when it is live-updated. In
+  """**For use with Docker Compose resources only.**
+
+  Specify that a container should be restarted when it is live-updated. In
   practice, this means that the container re-executes its `ENTRYPOINT` within
   the changed filesystem.
 
   May only be included in a `live_update` once, and only as the last step.
 
-  NOTE: this function will soon be deprecated. If you want to restart a Docker-built
-  image running on Kubernetes, use the `restart_process extension <https://github.com/windmilleng/tilt-extensions/tree/master/restart_process>`_.
-  At the moment, ``restart_container`` should only be used in conjunction
-  with ``custom_build`` or for images run by Docker Compose.
-
-  Only works on containers managed by Docker. For non-Docker runtimes
-  (e.g. containerd, CRI-O), please see the `wrapper script for simulating
-  restart_container <https://github.com/tilt-dev/rerun-process-wrapper>`_.
-
-  For more info, see the `Live Update Reference <live_update_reference.html>`_.
+  For more info (and for the equivalent functionality for Kubernetes resources),
+  see the `Live Update Reference <live_update_reference.html#restarting-your-process>`__.
   """
   pass
 

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -5877,6 +5877,11 @@ In any other case, an error reading
           </dt>
           <dd>
            <p>
+            <strong>
+             For use with Docker Compose resources only.
+            </strong>
+           </p>
+           <p>
             Specify that a container should be restarted when it is live-updated. In
 practice, this means that the container re-executes its
             <cite>
@@ -5893,39 +5898,9 @@ the changed filesystem.
             once, and only as the last step.
            </p>
            <p>
-            NOTE: this function will soon be deprecated. If you want to restart a Docker-built
-image running on Kubernetes, use the
-            <a class="reference external" href="https://github.com/windmilleng/tilt-extensions/tree/master/restart_process">
-             restart_process extension
-            </a>
-            .
-At the moment,
-            <code class="docutils literal notranslate">
-             <span class="pre">
-              restart_container
-             </span>
-            </code>
-            should only be used in conjunction
-with
-            <code class="docutils literal notranslate">
-             <span class="pre">
-              custom_build
-             </span>
-            </code>
-            or for images run by Docker Compose.
-           </p>
-           <p>
-            Only works on containers managed by Docker. For non-Docker runtimes
-(e.g. containerd, CRI-O), please see the
-            <a class="reference external" href="https://github.com/tilt-dev/rerun-process-wrapper">
-             wrapper script for simulating
-restart_container
-            </a>
-            .
-           </p>
-           <p>
-            For more info, see the
-            <a class="reference external" href="live_update_reference.html">
+            For more info (and for the equivalent functionality for Kubernetes resources),
+see the
+            <a class="reference external" href="live_update_reference.html#restarting-your-process">
              Live Update Reference
             </a>
             .


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch maiamcc/restart-container-api:

242bba4f1763d5969346d86de7871de98c06c01a (2020-06-12 12:16:20 -0400)
api: restart_container for docker compose only, add links

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics