### PR TITLE
Fix syntax err on win install cmd

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -81,7 +81,7 @@ kubectl config use-context docker-desktop
 - Install `tilt` with:
 
 ```bash
-iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.ps1')
+iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.ps1'))
 ```
 
 If you have [Scoop](https://scoop.sh) installed, the installer will use


### PR DESCRIPTION
The line to invoke the web request for installing on windows didn't have matching parenthesis. This is the fix for that.