### PR TITLE
docs: extension PRs should be prefixed with extension name

### DIFF
--- a/docs/contribute_extension.md
+++ b/docs/contribute_extension.md
@@ -22,7 +22,7 @@ extension_name/README.md
 README.md
 ```
 
-Create and submit a pull request to the repo, and @-mention `@victorwuky` for review.
+Create and submit a pull request to the repo, and @-mention `@victorwuky` for review. Your pull request should be prefixed with the name of your extension, e.g.: `min_tilt_version: fix bug foobar`.
 
 Currently there's no way to directly test the end-to-end workflow of using an extension. The Tilt team will ensure that the extension is working correctly before publishing it.
 


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/extension-pr-prefix:

5c1ad1cff52a13d9812552e386f567937c42c73f (2020-06-29 17:33:46 -0400)
docs: extension PRs should be prefixed with extension name

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics