### PR TITLE
api: updated parameters for local() in api doc

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -400,7 +400,7 @@ def load(path: str, *args):
     hi() # prints "Hello world!"
   """
 
-def local(command: Union[str, List[str]], quiet: bool = False, command_bat: str = "") -> Blob:
+def local(command: Union[str, List[str]], quiet: bool = False, command_bat: str = "", echo_off: bool = False) -> Blob:
   """Runs a command on the *host* machine, waits for it to finish, and returns its stdout as a ``Blob``
 
   Args:
@@ -408,6 +408,7 @@ def local(command: Union[str, List[str]], quiet: bool = False, command_bat: str 
     quiet: If set to True, skips printing output to log.
     command_bat: The command to run, expressed as a Windows batch command executed
       with ``cmd /S /C``. Takes precedence over the ``command`` parameter on Windows. Ignored on macOS/Linux.
+    echo_off: If set to True, skips printing command to log. 
   """
   pass
 

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -4639,6 +4639,10 @@ to share across Tiltfiles.
            <em>
             command_bat=&apos;&apos;
            </em>
+           ,
+           <em>
+            echo_off=False
+           </em>
            <span class="sig-paren">
             )
            </span>
@@ -4762,6 +4766,18 @@ with
                   </span>
                  </code>
                  parameter on Windows. Ignored on macOS/Linux.
+                </li>
+                <li>
+                 <strong>
+                  echo_off
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   bool
+                  </span>
+                 </code>
+                 ) &#x2013; If set to True, skips printing command to log.
                 </li>
                </ul>
               </td>


### PR DESCRIPTION
Hello @nicks ,

The API docs have been updated with the `echo_off` parameter to the `local()` function in the following commit: 
c72a22c3c9341a2e8d08546c9bc75b212294127d (Thu Jul 16 17:21:23 2020 +0400) - updated parameters for local() in api doc
adb23c4697e9c4d13100c2b38d806411671acb0d (Thu Jul 16 19:00:02 2020 +0400) -  updated parameters for local() in api doc

