### PR TITLE
Add Homebrew instructions to install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,13 @@ macOS
 kubectl config use-context docker-desktop
 ```
 
-- Install `tilt` with:
+- Install `tilt` with Homebrew:
+
+```bash
+brew install tilt-dev/homebrew-tap/tilt
+```
+
+- Alternatively without Homebrew, using the following command:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash


### PR DESCRIPTION
I noticed you folks [actively maintain a Homebrew tap](https://github.com/tilt-dev/homebrew-tap) for Tilt, but don't make any mention of it in the installation docs or the main repo's README.

Most macOS users that I'm aware of use Homebrew, and would prefer it to curling a script into `bash`. Defaulting to Homebrew is one less adoption barrier, and also means that the package can be upgraded much easier (`brew upgrade tilt`), and that it will auto-upgrade whenever users do a `brew upgrade`, helping you keep the Tilt userbase closer to the latest release :)

This PR, and [its accompanying PR](https://github.com/tilt-dev/tilt/pull/3613), add the missing documentation to make people aware of the `brew install` option

Also, there seems to have been an attempt to [upstream this into Homebrew's core tap](https://github.com/Homebrew/homebrew-core/pull/36309) that died out due to staleness. Maybe it would be worth trying to upstream it again?

Thanks for Tilt, it's been a really helpful tool so far 🎉