### PR TITLE
docs: add docs on pod_readiness

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -230,7 +230,8 @@ def k8s_resource(workload: str = "", new_name: str = "",
                  extra_pod_selectors: Union[Dict[str, str], List[Dict[str, str]]] = [],
                  trigger_mode: TriggerMode = TRIGGER_MODE_AUTO,
                  resource_deps: List[str] = [], objects: List[str] = [],
-                 auto_init: bool = True) -> None:
+                 auto_init: bool = True,
+                 pod_readiness: str = "") -> None:
   """
 
   Configures or creates the specified Kubernetes resource.
@@ -322,6 +323,10 @@ def k8s_resource(workload: str = "", new_name: str = "",
     auto_init: whether this resource runs on ``tilt up``. Defaults to ``True``.
       Note that ``auto_init=False`` is only compatible with
       ``trigger_mode=TRIGGER_MODE_MANUAL``.
+    pod_readiness: Possible values: 'ignore', 'wait'. Controls whether Tilt waits for
+      pods to be ready before the resource is considered healthy (and dependencies
+      can start building). By default, Tilt will wait for pods to be ready if it
+      thinks a resource has pods.
   """
   pass
 
@@ -408,7 +413,7 @@ def local(command: Union[str, List[str]], quiet: bool = False, command_bat: str 
     quiet: If set to True, skips printing output to log.
     command_bat: The command to run, expressed as a Windows batch command executed
       with ``cmd /S /C``. Takes precedence over the ``command`` parameter on Windows. Ignored on macOS/Linux.
-    echo_off: If set to True, skips printing command to log. 
+    echo_off: If set to True, skips printing command to log.
   """
   pass
 
@@ -469,7 +474,7 @@ def listdir(directory: str, recursive: bool = False) -> List[str]:
   Directory is watched (See ``watch_file``)."""
   pass
 
-def k8s_kind(kind: str, api_version: str=None, *, image_json_path: Union[str, List[str]]=[], image_object_json_path: Dict=None):
+def k8s_kind(kind: str, api_version: str=None, *, image_json_path: Union[str, List[str]]=[], image_object_json_path: Dict=None, pod_readiness: str=""):
   """Tells Tilt about a k8s kind.
 
   For CRDs that use images built by Tilt: call this with `image_json_path` or
@@ -497,6 +502,11 @@ def k8s_kind(kind: str, api_version: str=None, *, image_json_path: Union[str, Li
       This uses the k8s json path template syntax, described `here <https://kubernetes.io/docs/reference/kubectl/jsonpath/>`_.
     image_object: A specifier of the form `image_object={'json_path': '{.path.to.field}', 'repo_field': 'repo', 'tag_field': 'tag'}`.
       Used to tell Tilt how to inject images into Custom Resources that express the image repo and tag as separate fields.
+    pod_readiness: Possible values: 'ignore', 'wait'. Controls whether Tilt waits for
+      pods to be ready before the resource is considered healthy (and dependencies
+      can start building). By default, Tilt will wait for pods to be ready if it
+      thinks a resource has pods. This can be overridden on a resource-by-resource basis
+      by the `k8s_resource` function.
 
   """
   pass

--- a/docs/custom_resource.md
+++ b/docs/custom_resource.md
@@ -52,11 +52,28 @@ example](https://github.com/tilt-dev/tilt/blob/master/integration/crd/Tiltfile#L
 
 ### Does it create pods?
 
-Tilt can sometimes follow the Kubernetes metadata to figure out
-which pods belong to which resource. But other times it needs help.
+Tilt can sometimes follow the Kubernetes metadata to figure out which resources
+have pods, and which pods belong to which resource. But other times it needs
+help.
 
-To tell Tilt how to find the pods for a resource, you can use the `k8s_resource` function
-for each resource to specify a custom label selector for that resource.
+To tell Tilt that a resource has pods, and it should wait for them to become healthy:
+
+```python
+k8s_kind('UselessMachine', image_json_path='{.spec.image}', pod_readiness='wait')
+```
+
+To tell Tilt that a resource does NOT have pods, and it should consider a
+resource healthy if no pods come up:
+
+
+```python
+k8s_kind('UselessMachine', image_json_path='{.spec.image}', pod_readiness='ignore')
+```
+
+Most custom resources set owner references, which Tilt can follow to determine
+which pods belong to your resource. If your resource does not, you can use the
+`k8s_resource` function for each resource to specify a custom label selector for
+that resource.
 
 ```
 k8s_resource(new_name='postgres',

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -28,7 +28,7 @@ production cluster, Tilt will only push to clusters that have been whitelisted
 for local development.
            </p>
            <p>
-            By default, Tilt whitelists Minikube, Docker for Desktop, Microk8s, Red Hat CodeReady Containers, Kind, and K3D.
+            By default, Tilt whitelists Minikube, Docker for Desktop, Microk8s, Red Hat CodeReady Containers, Kind, K3D, and Krucible.
            </p>
            <p>
             To whitelist your development cluster, add a line in your Tiltfile:
@@ -3590,6 +3590,10 @@ import them into another Tiltfile, see the
            <em>
             image_object_json_path=None
            </em>
+           ,
+           <em>
+            pod_readiness=&apos;&apos;
+           </em>
            <span class="sig-paren">
             )
            </span>
@@ -3764,6 +3768,26 @@ This uses the k8s json path template syntax, described
                  .
 Used to tell Tilt how to inject images into Custom Resources that express the image repo and tag as separate fields.
                 </li>
+                <li>
+                 <strong>
+                  pod_readiness
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; Possible values: &#x2018;ignore&#x2019;, &#x2018;wait&#x2019;. Controls whether Tilt waits for
+pods to be ready before the resource is considered healthy (and dependencies
+can start building). By default, Tilt will wait for pods to be ready if it
+thinks a resource has pods. This can be overridden on a resource-by-resource basis
+by the
+                 <cite>
+                  k8s_resource
+                 </cite>
+                 function.
+                </li>
                </ul>
               </td>
              </tr>
@@ -3810,6 +3834,10 @@ Used to tell Tilt how to inject images into Custom Resources that express the im
            ,
            <em>
             auto_init=True
+           </em>
+           ,
+           <em>
+            pod_readiness=&apos;&apos;
            </em>
            <span class="sig-paren">
             )
@@ -4235,6 +4263,21 @@ Note that
                   </span>
                  </code>
                  .
+                </li>
+                <li>
+                 <strong>
+                  pod_readiness
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; Possible values: &#x2018;ignore&#x2019;, &#x2018;wait&#x2019;. Controls whether Tilt waits for
+pods to be ready before the resource is considered healthy (and dependencies
+can start building). By default, Tilt will wait for pods to be ready if it
+thinks a resource has pods.
                 </li>
                </ul>
               </td>


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/podreadiness:

bc8e6fb4dd5169e5c77ec66ce746109403e87780 (2020-07-31 13:18:33 -0400)
docs: add docs on pod_readiness

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics