### PR TITLE
docs: add api docs for cache_from, pull

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -79,7 +79,7 @@ def restart_container() -> LiveUpdateStep:
   """
   pass
 
-def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], match_in_env_vars: bool = False, ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = [], entrypoint: Union[str, List[str]] = [], target: str = "", ssh: Union[str, List[str]] = "", network: str = "", secret: Union[str, List[str]] = "", extra_tag: Union[str, List[str]] = "", container_args: List[str] = None) -> None:
+def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], match_in_env_vars: bool = False, ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = [], entrypoint: Union[str, List[str]] = [], target: str = "", ssh: Union[str, List[str]] = "", network: str = "", secret: Union[str, List[str]] = "", extra_tag: Union[str, List[str]] = "", container_args: List[str] = None, cache_from: Union[str, List[str]] = [], pull: bool = False) -> None:
   """Builds a docker image.
 
   The invocation
@@ -117,6 +117,8 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
     secret: Include secrets in your build in a way that won't show up in the image. Uses the same syntax as the `docker build --secret flag <https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information>`_.
     extra_tag: Tag an image with one or more extra references after each build. Useful when running Tilt in a CI pipeline, where you want each image to be tagged with the pipeline ID so you can find it later. Uses the same syntax as the ``docker build --tag`` flag.
     container_args: args to run when this container starts. Takes precedence over a `container args specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_.
+    cache_from: Cache image builds from a remote registry. Uses the same syntax as `docker build --cache-from flag <https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources>`_.
+    pull: Force pull the latest version of parent images. Equivalent to the ``docker build --pull`` flag.
   """
   pass
 
@@ -408,7 +410,7 @@ def local(command: Union[str, List[str]], quiet: bool = False, command_bat: str 
     quiet: If set to True, skips printing output to log.
     command_bat: The command to run, expressed as a Windows batch command executed
       with ``cmd /S /C``. Takes precedence over the ``command`` parameter on Windows. Ignored on macOS/Linux.
-    echo_off: If set to True, skips printing command to log. 
+    echo_off: If set to True, skips printing command to log.
   """
   pass
 

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -28,7 +28,7 @@ production cluster, Tilt will only push to clusters that have been whitelisted
 for local development.
            </p>
            <p>
-            By default, Tilt whitelists Minikube, Docker for Desktop, Microk8s, Red Hat CodeReady Containers, Kind, and K3D.
+            By default, Tilt whitelists Minikube, Docker for Desktop, Microk8s, Red Hat CodeReady Containers, Kind, K3D, and Krucible.
            </p>
            <p>
             To whitelist your development cluster, add a line in your Tiltfile:
@@ -1512,6 +1512,14 @@ ensures a pretty high bar of intent.
            <em>
             container_args=None
            </em>
+           ,
+           <em>
+            cache_from=[]
+           </em>
+           ,
+           <em>
+            pull=False
+           </em>
            <span class="sig-paren">
             )
            </span>
@@ -2068,6 +2076,64 @@ ensures a pretty high bar of intent.
                   container args specified in k8s YAML
                  </a>
                  .
+                </li>
+                <li>
+                 <strong>
+                  cache_from
+                 </strong>
+                 (
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Union
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ,
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   List
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ]]) &#x2013; Cache image builds from a remote registry. Uses the same syntax as
+                 <a class="reference external" href="https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources">
+                  docker build &#x2013;cache-from flag
+                 </a>
+                 .
+                </li>
+                <li>
+                 <strong>
+                  pull
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   bool
+                  </span>
+                 </code>
+                 ) &#x2013; Force pull the latest version of parent images. Equivalent to the
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   docker
+                  </span>
+                  <span class="pre">
+                   build
+                  </span>
+                  <span class="pre">
+                   --pull
+                  </span>
+                 </code>
+                 flag.
                 </li>
                </ul>
               </td>


### PR DESCRIPTION
Hello @victorwuky,

Please review the following commits I made in branch nicks/cachefrom:

c929082c0303c0ec99f745653f66cfe5f1df57eb (2020-07-31 13:26:11 -0400)
docs: add api docs for cache_from, pull

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics