### PR TITLE
docs: remove calendly link from the install page

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,8 +6,6 @@ has_calendly: true
 has_calendly_popup: true
 ---
 
-_Having trouble getting started with Tilt? <a href="" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/dmiller-tilt/30min'});return false;">Schedule a video call with Dan Miller</a>, Senior Software Engineer at Tilt._
-
 Tilt is available for [macOS](#macos), [Linux](#linux), and [Windows](#windows).
 
 You'll also need:


### PR DESCRIPTION
We ran this experiment for a month and never got any clicks,
let's remove the clutter.