### PR TITLE
Add Tilt in Two Minutes video

### DIFF
--- a/src/_sass/home.scss
+++ b/src/_sass/home.scss
@@ -536,6 +536,26 @@ $Home-feature-navList-width: 35%;
 }
 
 
+// Video --------------------------------------------------
+
+// https://css-tricks.com/fluid-width-video/
+
+.Home-video {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 */
+  height: 0;
+  margin-bottom: $spacing-unit * 3;
+  @include shadow;
+}
+
+.Home-video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 // Testimonials --------------------------------------------------
 .Home-sectionHeading--testimonials {
   display: flex;

--- a/src/index.md
+++ b/src/index.md
@@ -192,6 +192,11 @@ has_calendly: true
 </ul>
 </div>
 
+<h3 class="Home-sectionHeading">See Tilt in Action</h3>
+<div class="Home-video">
+  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/FSMc3kQgd5Y" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 <h3 class="Home-sectionHeading">Learn More</h3>
 <section class="Home-resources">
   <ul class="Home-resources-list">


### PR DESCRIPTION
One issue — Firefox complains "www.youtube.com will not allow Firefox to display the page if another site has embedded it." It works in Firefox Private Browsing and in Chrome and Safari, though. 

<img width="1274" alt="Screen Shot 2020-08-06 at 11 16 48 AM" src="https://user-images.githubusercontent.com/20349/89549492-5e1aa880-d7d6-11ea-9f0f-a59924d7b134.png">
