### PR TITLE
site: fix YouTube display on Firefox

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -194,7 +194,7 @@ has_calendly: true
 
 <h3 class="Home-sectionHeading">See Tilt in Action</h3>
 <div class="Home-video">
-  <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/FSMc3kQgd5Y" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/FSMc3kQgd5Y?controls=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
 <h3 class="Home-sectionHeading">Learn More</h3>


### PR DESCRIPTION
Fun fact! If you enable this setting when embedding a YouTube video...

<img width="422" alt="Screen Shot 2020-08-06 at 11 32 51 AM" src="https://user-images.githubusercontent.com/20349/89551572-19dcd780-d7d9-11ea-97c0-3b8599004984.png">

...Firefox may refuse to show the embedded video and display this error!

```
To protect your security, www.youtube.com will not allow Firefox to display the page if another site has embedded it. To see this page, you need to open it in a new window.
```