### PR TITLE
site: Fix Schedule a demo button text so it is not clipped on mobile

### DIFF
--- a/src/_sass/home.scss
+++ b/src/_sass/home.scss
@@ -111,9 +111,8 @@
   font-family: $tilt2-font-sans;
   font-size: $tilt2-button-font-size--large;
   font-weight: $tilt2-font-weight-sans-bold;
-  padding: 0;
   height: $tilt2-button-height--large;
-  width: 270px;
+  min-width: 270px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -122,6 +121,7 @@
   color: $tilt2-color-gray;
   box-sizing: border-box;
   cursor: pointer;
+  white-space: nowrap;
 
   &:hover {
     color: $color-white;

--- a/src/_sass/home.scss
+++ b/src/_sass/home.scss
@@ -111,6 +111,7 @@
   font-family: $tilt2-font-sans;
   font-size: $tilt2-button-font-size--large;
   font-weight: $tilt2-font-weight-sans-bold;
+  padding: 0;
   height: $tilt2-button-height--large;
   width: 270px;
   display: flex;


### PR DESCRIPTION
Could not reproduce it on Chrome/Safari on mac (using the developer tool console). But verified this on my physical iPhone 11. And debugged it using remote mobile web dev (i.e. connected phone to computer and ran the inspector on my computer against mobile safari running on phone).


| Before | After |
| --- | --- |
| ![IMG_3698](https://user-images.githubusercontent.com/10860550/89849005-982cd700-db55-11ea-8ae2-4e5278142d2d.PNG) | ![IMG_3699](https://user-images.githubusercontent.com/10860550/89848977-851a0700-db55-11ea-966d-3154472ceae7.PNG) |
