### PR TITLE
Adds instructions to install tilt via asdf

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -143,6 +143,14 @@ conda config --add channels conda-forge
 conda install tilt
 ```
 
+## asdf
+
+```
+asdf plugin add tilt
+asdf install tilt 0.17.1
+asdf global tilt 0.17.1
+```
+
 ### Manual Install
 
 If you don't have a package manager installed, the installer will download a

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -47,6 +47,14 @@ scoop update tilt
 conda update -c conda-forge tilt
 ```
 
+## asdf
+
+```
+asdf plugin add tilt
+asdf install tilt 0.17.1
+asdf global tilt 0.17.1
+```
+
 ## Manual Install
 If you installed Tilt manually by downloading a release binary and moving in to your PATH you may need to do the same to upgrade.
 


### PR DESCRIPTION
[asdf](https://github.com/asdf-vm/asdf) is a useful tool for managing CLI tools. This PR updates the documentation to detail how to install tilt via asdf.