### PR TITLE
tilt.build: fix inject_stars on bsd

### DIFF
--- a/stars/inject_stars.sh
+++ b/stars/inject_stars.sh
@@ -5,4 +5,5 @@ cd $(dirname $0)
 set -ex
 yarn install
 STARS=$(node stars.js)
-sed -i'' -e "s/stars: .*/stars: $STARS/" ../src/_data/github.yml
+sed -i.bak -e "s/stars: .*/stars: $STARS/" ../src/_data/github.yml
+rm -f ../src/_data/github.yml.bak


### PR DESCRIPTION
this script has been leaving behind "github.yml-e" files on my mac