### PR TITLE
fix a typo

### DIFF
--- a/docs/custom_resource.md
+++ b/docs/custom_resource.md
@@ -150,7 +150,7 @@ If you have an example of a custom resource with Tilt you'd like to share, feel 
 - [Airflow](https://github.com/tilt-dev/tilt-example-frameworks/tree/master/airflow) -
   Deploy an Airflow cluster and iterate on tasks. This doesn't use custom resources
   but it demonstrate alternative ways of using and injecting images.
-- [Prometheus](https://github.com/tilt-dev/tilt-example-frameworks/tree/master/prometheus)
+- [Prometheus](https://github.com/tilt-dev/tilt-example-frameworks/tree/master/prometheus) -
   Deploy the Prometheus operator and an instance of Prometheus. Demonstrates how to
   use resource dependencies and pod selectors to install the CRDs in the right order,
   and monitor the pods created by those CRDs.


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/prometheus:

455c308ed4ef84ede4f966baad779158712334d7 (2020-08-26 17:12:23 -0400)
fix a typo

5143c003361129a1696db8de78a5d6d4ce07772a (2020-08-26 17:01:35 -0400)
docs: add a note on the prometheus example

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics