### PR TITLE
fix microk8s setup instructions

### DIFF
--- a/docs/choosing_clusters.md
+++ b/docs/choosing_clusters.md
@@ -93,7 +93,8 @@ Make microk8s your local Kubernetes cluster:
 
 ```bash
 sudo microk8s.kubectl config view --flatten > ~/.kube/microk8s-config && \
-KUBECONFIG=~/.kube/microk8s-config:~/.kube/config kubectl config view --flatten > ~/.kube/temp-config && \
+KUBECONFIG=~/.kube/microk8s-config:~/.kube/config && \
+kubectl config view --flatten > ~/.kube/temp-config && \
 mv ~/.kube/temp-config ~/.kube/config && \
 kubectl config use-context microk8s
 ```


### PR DESCRIPTION
add missing `&&` and line break to microk8s setup instructions in "choosing a cluster"