### PR TITLE
docs: change the default cluster instructions to recommend Kind on Linux

### DIFF
--- a/docs/choosing_clusters.md
+++ b/docs/choosing_clusters.md
@@ -79,7 +79,7 @@ In the Docker For Mac preferences, click
 
 ## MicroK8s
 
-[Microk8s](https://microk8s.io) is what we recommend most often for Linux users.
+[Microk8s](https://microk8s.io) is what we recommend most often for Ubuntu users.
 
 Install:
 
@@ -109,7 +109,10 @@ kubectl config use-context microk8s
 ### Cons
 
 - Resetting the cluster is slow and error-prone.
-- Optimized for Linux. You can use it on MacOS and Windows with [Multipass](https://multipass.run/).
+- Optimized for Ubuntu. In theory, works on any Linux that supports
+  [Snap](https://snapcraft.io/) and on MacOS/Windows with
+  [Multipass](https://multipass.run/), but t's
+  not as stable on those platforms.
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,28 +39,17 @@ Linux
 - Install [Docker](https://docs.docker.com/install/)
 - Setup Docker as [a non-root user](https://docs.docker.com/install/linux/linux-postinstall/).
 - Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- Install [Microk8s](https://microk8s.io/):
-
-```bash
-sudo snap install microk8s --classic && \
-sudo microk8s.enable dns && \
-sudo microk8s.enable registry
-```
-
-- Make microk8s your local Kubernetes cluster:
-
-```bash
-sudo microk8s.kubectl config view --flatten > ~/.kube/microk8s-config && \
-KUBECONFIG=~/.kube/microk8s-config:~/.kube/config kubectl config view --flatten > ~/.kube/temp-config && \
-mv ~/.kube/temp-config ~/.kube/config && \
-kubectl config use-context microk8s
-```
-
+- Install [Kind with a a local registry](https://github.com/tilt-dev/kind-local/blob/master/README.md)
 - Install `tilt` with:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
 ```
+
+Alternatively, Ubuntu users sometimes prefer
+[Microk8s](choosing_clusters.html#microk8s) instead of Kind because it
+integrates well with Ubuntu. See the [Choosing a Local Dev Cluster](choosing_clusters.html)
+guide for more Linux options.
 
 Windows
 ---------------


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch9397:

5dde607b70ae6b2dbebeda0d491c08f9c09f1863 (2020-09-16 18:36:34 -0400)
docs: change the default cluster instructions to recommend Kind on Linux
Fixes https://github.com/tilt-dev/tilt/issues/3772

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics