### PR TITLE
add the coreos_prometheus extension to the api docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,7 @@ Tilt users can contribute [extensions](extensions.html) to share with other user
 examples of what you can do with a Tiltfile. Load them into your own Tiltfile. Includes:
 
 - [`conftest`](https://github.com/tilt-dev/tilt-extensions/tree/master/conftest): Use [Conftest](https://www.conftest.dev/) to test your configuration files.
+- [`coreos_prometheus`](https://github.com/tilt-dev/tilt-extensions/tree/master/coreos_prometheus): Deploys Prometheus to a monitoring namespace, managed by the CoreOS Prometheus Operator and CRDs
 - [`docker_build_sub`](https://github.com/tilt-dev/tilt-extensions/tree/master/docker_build_sub): Specify extra Dockerfile directives in your Tiltfile beyond [`docker_build`](https://docs.tilt.dev/api.html#api.docker_build).
 - [`file_sync_only`](https://github.com/tilt-dev/tilt-extensions/tree/master/file_sync_only): No-build, no-push, file sync-only development. Useful when you want to live-reload a single config file into an existing public image, like nginx.
 - [`git_resource`](https://github.com/tilt-dev/tilt-extensions/tree/master/git_resource): Deploy a dockerfile from a remote repository -- or specify the path to a local checkout for local development.


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/prometheus2:

b003e7b2705ecfb0efae8ab33c7b53c13e173efc (2020-09-16 18:46:07 -0400)
add the coreos_prometheus extension to the api docs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics