### PR TITLE
add snyk extension to api docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,7 @@ examples of what you can do with a Tiltfile. Load them into your own Tiltfile. I
 - [`procfile`](https://github.com/tilt-dev/tilt-extensions/tree/master/procfile): Create Tilt resources from a foreman Procfile.
 - [`restart_process`](https://github.com/tilt-dev/tilt-extensions/tree/master/restart_process): Wrap a `docker_build` to restart the given entrypoint after a Live Update (replaces `restart_container()`)
 - [`secret`](https://github.com/tilt-dev/tilt-extensions/tree/master/secret): Functions for creating secrets.
+- [`snyk`](https://github.com/tilt-dev/tilt-extensions/tree/master/snyk): Use [Snyk](https://snyk.io) to test your configuration files.
 
 ## Data
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/snyk:

d1541551c166837d796b6744d22b783da3dc40e6 (2020-09-21 19:30:27 -0400)
add snyk extension to api docs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics