### PR TITLE
Match the documentation for port_forward args

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -30,7 +30,7 @@ class PortForward:
 
 def port_forward(local_port: int,
                  container_port: Optional[int] = None,
-                 link_text: Optional[str] = None) -> PortForward:
+                 name: Optional[str] = None) -> PortForward:
   """
   Creates a :class:`~api.PortForward` object specifying how to set up and display a Kubernetes port forward.
 

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -5677,7 +5677,7 @@ conditions around modifying a shared file system. Set to True to allow them to r
            </em>
            ,
            <em>
-            link_text=None
+            name=None
            </em>
            <span class="sig-paren">
             )


### PR DESCRIPTION
Hi there 👋 

I've been using this framework recently as a dive into making our micro-service development easier. Love what you all have build!

Just addressing a small change in the documentation. It seems "link_text" doesn't work and the "name" does. Just want to see if this was a problem. For example: 

```
k8s_resource('cool-service',
  port_forwards=[
    port_forward(8080, container_port=8080, name='rest-api'),
    port_forward(8081, container_port=5858, name='node-debugger')
  ],
  resource_deps=['cool-service-db']
)
```

Thanks for all the hard work!
