### PR TITLE
docs: Inclusive wording changes

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -827,12 +827,12 @@ def allow_k8s_contexts(contexts: Union[str, List[str]]) -> None:
   """Specifies that Tilt is allowed to run against the specified k8s context names.
 
   To help reduce the chances you accidentally use Tilt to deploy to your
-  production cluster, Tilt will only push to clusters that have been whitelisted
+  production cluster, Tilt will only push to clusters that have been allowed
   for local development.
 
-  By default, Tilt whitelists Minikube, Docker for Desktop, Microk8s, Red Hat CodeReady Containers, Kind, K3D, and Krucible.
+  By default, Tilt automatically allows Minikube, Docker for Desktop, Microk8s, Red Hat CodeReady Containers, Kind, K3D, and Krucible.
 
-  To whitelist your development cluster, add a line in your Tiltfile:
+  To add your development cluster to the allow list, add a line in your Tiltfile:
 
   `allow_k8s_contexts('context-name')`
 

--- a/blog/_posts/2019-09-09-commit-of-the-month-august.md
+++ b/blog/_posts/2019-09-09-commit-of-the-month-august.md
@@ -33,7 +33,7 @@ The point, simply, is to keep you from `tilt up`-ing your local code into your p
 
 This feature uses heuristics to guess whether you’re running in a local cluster (like Minikube or Docker Desktop). Local cluster are obviously not production, so they’re always safe. If your KubeContext is _not_ pointing to something that we can identify as a local cluster, then we block your deploy and throw up this warning instead.
 
-If you were in fact pointing at your production cluster, then yay, crisis averted! If you actually _meant_ to deploy to this cluster (say, it’s your staging cluster, or maybe you’re excited about all the benefits you get from developing against a remote k8s cluster), you can easily [whitelist the cluster in your Tiltfile](https://docs.tilt.dev/api.html#api.allow_k8s_contexts), and Tilt won’t bother you about it anymore. (You don’t even to have to restart Tilt, because it’s responsive to changes in your Tiltfile!)
+If you were in fact pointing at your production cluster, then yay, crisis averted! If you actually _meant_ to deploy to this cluster (say, it’s your staging cluster, or maybe you’re excited about all the benefits you get from developing against a remote k8s cluster), you can easily [allow the cluster in your Tiltfile](https://docs.tilt.dev/api.html#api.allow_k8s_contexts), and Tilt won’t bother you about it anymore. (You don’t even to have to restart Tilt, because it’s responsive to changes in your Tiltfile!)
 
 ```
 allow_k8s_contexts('my-staging-cluster')

--- a/docs/choosing_clusters.md
+++ b/docs/choosing_clusters.md
@@ -179,7 +179,7 @@ instructions linked above)
 By default, Tilt will not let you develop against a remote cluster.
 
 If you start Tilt while you have `kubectl` configured to talk to a remote
-cluster, you will get an error. You have to explicitly whitelist the cluster 
+cluster, you will get an error. You have to explicitly allow the cluster 
 using [allow_k8s_contexts](api.html#api.allow_k8s_contexts):
 
 ```python
@@ -213,16 +213,16 @@ want it to work with Tilt, there are two things you need to do.
 - Tilt needs to recognize the cluster as a dev cluster.
 - Tilt needs to be able to discover any in-cluster registry.
 
-### Whitelisting the Cluster
+### Allowing the Cluster
 
-Users have to explicitly whitelist the cluster with this line in their Tiltfile:
+Users have to explicitly allow the cluster with this line in their Tiltfile:
 
 ```python
 allow_k8s_contexts('my-cluster-name')
 ```
 
 If your cluster is a dev-only cluster that you think Tilt should
-recognize automatically, we accept PRs to whitelist the cluster in Tilt.
+recognize automatically, we accept PRs to allow the cluster in Tilt.
 Here's an example:
 
 [Recognize Red Hat CodeReady Containers as a local cluster](https://github.com/tilt-dev/tilt/pull/3242)

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -24,14 +24,14 @@
            </p>
            <p>
             To help reduce the chances you accidentally use Tilt to deploy to your
-production cluster, Tilt will only push to clusters that have been whitelisted
+production cluster, Tilt will only push to clusters that have been allowed
 for local development.
            </p>
            <p>
-            By default, Tilt whitelists Minikube, Docker for Desktop, Microk8s, Red Hat CodeReady Containers, Kind, K3D, and Krucible.
+            By default, Tilt automatically allows Minikube, Docker for Desktop, Microk8s, Red Hat CodeReady Containers, Kind, K3D, and Krucible.
            </p>
            <p>
-            To whitelist your development cluster, add a line in your Tiltfile:
+            To add your development cluster to the allow list, add a line in your Tiltfile:
            </p>
            <p>
             <cite>

--- a/src/_includes/functions.html
+++ b/src/_includes/functions.html
@@ -24,14 +24,14 @@
            </p>
            <p>
             To help reduce the chances you accidentally use Tilt to deploy to your
-production cluster, Tilt will only push to clusters that have been whitelisted
+production cluster, Tilt will only push to clusters that have been allowed
 for local development.
            </p>
            <p>
-            By default, Tilt whitelists Minikube, Docker for Desktop, Microk8s, Kind, and K3D.
+            By default, Tilt automatically allows Minikube, Docker for Desktop, Microk8s, Kind, and K3D.
            </p>
            <p>
-            To whitelist your development cluster, add a line in your Tiltfile:
+            To add your your development cluster to the allow list, add a line in your Tiltfile:
            </p>
            <p>
             <cite>


### PR DESCRIPTION
Changes wording in Documentation / Blog Post from using the term 'whitelist' to the term 'allow', creating better matching internal code feature phrasing and community inclusiveness.