### PR TITLE
docs: Fix command to use microk8s cluster

### DIFF
--- a/docs/choosing_clusters.md
+++ b/docs/choosing_clusters.md
@@ -92,8 +92,7 @@ Make microk8s your local Kubernetes cluster:
 
 ```bash
 sudo microk8s.kubectl config view --flatten > ~/.kube/microk8s-config && \
-KUBECONFIG=~/.kube/microk8s-config:~/.kube/config && \
-kubectl config view --flatten > ~/.kube/temp-config && \
+KUBECONFIG=~/.kube/microk8s-config:~/.kube/config kubectl config view --flatten > ~/.kube/temp-config && \
 mv ~/.kube/temp-config ~/.kube/config && \
 kubectl config use-context microk8s
 ```


### PR DESCRIPTION
`KUBECONFIG` was set but not actually used.

An alternative to this PR is to `export KUBECONFIG=...` to keep the lines short, but that could have side-effects.