### PR TITLE
fix typo in `custom_build` args `ignore` key

### DIFF
--- a/docs/custom_build.md
+++ b/docs/custom_build.md
@@ -185,7 +185,7 @@ custom_build(
     'image-foo',
     'docker build -t $EXPECTED_REF .',
     deps=['dep1', 'dep2'],
-    ignores=['baz']
+    ignore=['baz']
 )
 ```
 Tilt will ignore `dep1/baz` and `dep2/baz`.


### PR DESCRIPTION
On Tilt v0.17.11, as documented, the `ignores` key will throw an error
Using `ignore` is accepted