### PR TITLE
document the host parameter on port-forwards

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -357,19 +357,18 @@ def k8s_resource(workload: str = "", new_name: str = "",
       in conjunction with ``new_name``.)
     new_name: If non-empty, will be used as the new name for this resource. (To
       programmatically rename all resources, see :meth:`workload_to_resource_function`.)
-    port_forwards: Local ports to connect to the pod. If a target port is
-      specified, that will be used. Otherwise, if the container exposes a port
-      with the same number as the local port, that will be used. Otherwise,
-      the default container port will be used. Port forward configurations may
-      also be specified with a :class:`~api.PortForward` object.
-      Example values: 9000 (connect localhost:9000 to the container's port 9000,
-      if it is exposed, otherwise connect to the container's default port),
-      '9000:8000' (connect localhost:9000 to the container port 8000),
-      ['9000:8000', '9001:8001'] (connect localhost:9000 and :9001 to the
-      container ports 8000 and 8001, respectively).
-      [8000, 8001] (assuming the container exposes both 8000 and 8001, connect
-      localhost:8000 and localhost:8001 to the container's ports 8000 and 8001,
-      respectively).
+    port_forwards: Host port to connect to the pod. Takes 3 forms:
+
+      ``'9000'`` (port only) - Connect localhost:9000 to the container's port 9000,
+      if it is exposed. Otherwise connect to the container's default port.
+
+      ``'9000:8000'`` (host port to container port) - Connect localhost:9000 to the container port 8000).
+
+      ``'elastic.local:9200:8000'`` (host address to container port) - Bind elasticsearch:9200 on the host
+      to container port 8000. You will also need to update /etc/host to make 'elastic.local' point to localhost.
+
+      Multiple port forwards can be specified (e.g., ``['9000:8000', '9001:8001']``).
+      The string-based syntax is sugar over the more explicit ``port_forward(9000, 8000)``.
     extra_pod_selectors: In addition to relying on Tilt's heuristics to automatically
       find Kubernetes resources associated with this resource, a user may specify extra
       labelsets to force pods to be associated with this resource. An pod

--- a/src/_data/github.yml
+++ b/src/_data/github.yml
@@ -1,2 +1,2 @@
-stars: 3.9k
+stars: 4.0k
 href: https://github.com/tilt-dev/tilt

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -4162,27 +4162,58 @@ programmatically rename all resources, see
                    </span>
                   </code>
                  </a>
-                 ]]]) &#x2013; Local ports to connect to the pod. If a target port is
-specified, that will be used. Otherwise, if the container exposes a port
-with the same number as the local port, that will be used. Otherwise,
-the default container port will be used. Port forward configurations may
-also be specified with a
-                 <a class="reference internal" href="#api.PortForward" title="api.PortForward">
-                  <code class="xref py py-class docutils literal notranslate">
+                 ]]]) &#x2013;
+                 <p>
+                  Host port to connect to the pod. Takes 3 forms:
+                 </p>
+                 <p>
+                  <code class="docutils literal notranslate">
                    <span class="pre">
-                    PortForward
+                    &apos;9000&apos;
                    </span>
                   </code>
-                 </a>
-                 object.
-Example values: 9000 (connect localhost:9000 to the container&#x2019;s port 9000,
-if it is exposed, otherwise connect to the container&#x2019;s default port),
-&#x2018;9000:8000&#x2019; (connect localhost:9000 to the container port 8000),
-[&#x2018;9000:8000&#x2019;, &#x2018;9001:8001&#x2019;] (connect localhost:9000 and :9001 to the
-container ports 8000 and 8001, respectively).
-[8000, 8001] (assuming the container exposes both 8000 and 8001, connect
-localhost:8000 and localhost:8001 to the container&#x2019;s ports 8000 and 8001,
-respectively).
+                  (port only) - Connect localhost:9000 to the container&#x2019;s port 9000,
+if it is exposed. Otherwise connect to the container&#x2019;s default port.
+                 </p>
+                 <p>
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    &apos;9000:8000&apos;
+                   </span>
+                  </code>
+                  (host port to container port) - Connect localhost:9000 to the container port 8000).
+                 </p>
+                 <p>
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    &apos;elastic.local:9200:8000&apos;
+                   </span>
+                  </code>
+                  (host address to container port) - Bind elasticsearch:9200 on the host
+to container port 8000. You will also need to update /etc/host to make &#x2018;elastic.local&#x2019; point to localhost.
+                 </p>
+                 <p>
+                  Multiple port forwards can be specified (e.g.,
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    [&apos;9000:8000&apos;,
+                   </span>
+                   <span class="pre">
+                    &apos;9001:8001&apos;]
+                   </span>
+                  </code>
+                  ).
+The string-based syntax is sugar over the more explicit
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    port_forward(9000,
+                   </span>
+                   <span class="pre">
+                    8000)
+                   </span>
+                  </code>
+                  .
+                 </p>
                 </li>
                 <li>
                  <strong>


### PR DESCRIPTION
Hello @maiamcc, @ellenkorbes,

Please review the following commits I made in branch nicks/portforward:

78fe764de51f21de9f2783d4b1a4b747e7761794 (2020-12-02 11:27:12 -0500)
document the host parameter on port-forwards

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics