### PR TITLE
docs: also add the security policy to the docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,9 @@ status of running services, errors, logs, and more.
 **Contribute:** Tilt is open source, developed on [GitHub](https://github.com/tilt-dev/tilt). Check out our [contribution](https://github.com/tilt-dev/tilt/blob/master/CONTRIBUTING.md) guidelines. 
 
 **Follow along:** [@tilt_dev](https://twitter.com/tilt_dev) on Twitter. Updates
-and announcements on the [Tilt blog](https://blog.tilt.dev).
+and announcements on the [Tilt blog](https://blog.tilt.dev). If you find a
+security issue in Tilt, see our [security
+policy](https://github.com/tilt-dev/tilt/blob/master/SECURITY.md).
 
 **Help us make Tilt even better:** Tilt sends anonymized usage data, so we can
 improve Tilt on every platform. Details in ["What does Tilt


### PR DESCRIPTION
Hello @victorwuky,

Please review the following commits I made in branch nicks/security:

3679ec8da25d8ceb1e504aed4144f360aaa4f358 (2020-12-18 12:19:01 -0500)
docs: also add the security policy to the docs site

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics