### PR TITLE
docs: add docs for warn()

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1035,7 +1035,7 @@ def watch_settings(ignore: Union[str, List[str]]) -> None:
 def warn(msg: str) -> None:
   """Emits a warning.
 
-  Warnings are displayed both in the logs, and aggregated as alerts.
+  Warnings are both displayed in the logs and aggregated as alerts.
 
   Args:
     msg: The message.

--- a/api/api.py
+++ b/api/api.py
@@ -1031,3 +1031,12 @@ def watch_settings(ignore: Union[str, List[str]]) -> None:
       patterns to .tiltignore. Relative patterns are evaluated relative to the current working dir.
       See `Debugging File Changes <file_changes.html>`_ for more details.
   """
+
+def warn(msg: str) -> None:
+  """Emits a warning.
+
+  Warnings are displayed both in the logs, and aggregated as alerts.
+
+  Args:
+    msg: The message.
+  """

--- a/src/_data/api/functions.yaml
+++ b/src/_data/api/functions.yaml
@@ -46,6 +46,7 @@ functions:
 - trigger_mode
 - update_settings
 - version_settings
+- warn
 - watch_file
 - watch_settings
 - workload_to_resource_function

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -7583,7 +7583,7 @@ Examples:
             Emits a warning.
            </p>
            <p>
-            Warnings are displayed both in the logs, and aggregated as alerts.
+            Warnings are both displayed in the logs and aggregated as alerts.
            </p>
            <table class="docutils field-list" frame="void" rules="none">
             <col class="field-name">

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -7559,6 +7559,69 @@ Examples:
            </table>
           </dd>
          </dl><dl class="function">
+          <dt id="api.warn">
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            warn
+           </code>
+           <span class="sig-paren">
+            (
+           </span>
+           <em>
+            msg
+           </em>
+           <span class="sig-paren">
+            )
+           </span>
+           <a class="headerlink" href="#api.warn" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Emits a warning.
+           </p>
+           <p>
+            Warnings are displayed both in the logs, and aggregated as alerts.
+           </p>
+           <table class="docutils field-list" frame="void" rules="none">
+            <col class="field-name">
+            <col class="field-body">
+            <tbody valign="top">
+             <tr class="field-odd field">
+              <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <strong>
+                msg
+               </strong>
+               (
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 str
+                </span>
+               </code>
+               ) &#x2013; The message.
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
+               Return type:
+              </th>
+              <td class="field-body">
+               <code class="docutils literal notranslate">
+                <span class="pre">
+                 None
+                </span>
+               </code>
+              </td>
+             </tr>
+            </tbody>
+           </table>
+          </dd>
+         </dl><dl class="function">
           <dt id="api.watch_file">
            <code class="descclassname">
            </code>


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch10608:

856207a11320ababc0828c5f7e9bf33d6b5fbb00 (2021-01-05 14:05:25 -0500)
docs: add docs for warn()

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics