### PR TITLE
docs: add info on Extensions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,9 +70,9 @@ status of running services, errors, logs, and more.
 
 **Questions and feedback:** Join [the Kubernetes slack](http://slack.k8s.io) and
  find us in the [#tilt](https://kubernetes.slack.com/messages/CESBL84MV/)
- channel. Or [file an issue](https://github.com/tilt-dev/tilt/issues).
+ channel. Or [file an issue](https://github.com/tilt-dev/tilt/issues). To get code snippets of Tiltfile functionality shared by the Tilt community, check out [Tilt Extensions](https://github.com/tilt-dev/tilt-extensions).
 
-**Contribute:** Tilt is open source, developed on [GitHub](https://github.com/tilt-dev/tilt). Check out our [contribution](https://github.com/tilt-dev/tilt/blob/master/CONTRIBUTING.md) guidelines. 
+**Contribute:** Tilt is open source, developed on [GitHub](https://github.com/tilt-dev/tilt). Check out our [contribution](https://github.com/tilt-dev/tilt/blob/master/CONTRIBUTING.md) guidelines. To extend the capabilities of Tilt via new Tiltfile functionality, read more on [Extensions](https://docs.tilt.dev/extensions.html). 
 
 **Follow along:** [@tilt_dev](https://twitter.com/tilt_dev) on Twitter. Updates
 and announcements on the [Tilt blog](https://blog.tilt.dev). If you find a


### PR DESCRIPTION
Last week, different people in #tilt didn't seem aware of Tilt Extensions related to their issues. Let's talk up Extensions in our docs more!