### PR TITLE
install/upgrade: bump tilt version numbers for asdf in upgrade.md

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -51,8 +51,8 @@ conda update -c conda-forge tilt
 
 ```
 asdf plugin add tilt
-asdf install tilt 0.17.3
-asdf global tilt 0.17.3
+asdf install tilt v0.18.5
+asdf global tilt v0.18.5
 ```
 
 ## Manual Install


### PR DESCRIPTION
script is fixed in https://github.com/tilt-dev/tilt/pull/4110 but we missed it this time around (ty @jazzdan for https://github.com/tilt-dev/tilt.build/pull/801/ !)