### PR TITLE
docs: add readiness_probe for local_resource to docs + API

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1051,3 +1051,96 @@ def warn(msg: str) -> None:
   Args:
     msg: The message.
   """
+
+
+class Probe:
+  """Specification for a resource readiness check.
+
+  For details, see the :meth:`probe` function.
+  """
+  pass
+
+
+class ExecAction:
+  """Specification for a command to execute that determines resource readiness.
+
+  For details, see the :func:`probe` and :func:`exec_action` functions.
+  """
+  pass
+
+
+class HTTPGetAction:
+  """Specification for a HTTP GET request to perform that determines resource readiness.
+
+  For details, see the :func:`probe` and :func:`http_get_action` functions.
+  """
+  pass
+
+
+class TCPSocketAction:
+  """Specification for a TCP socket connection to perform that determines resource readiness.
+
+  For details, see the :func:`probe` and :func:`tcp_socket_action` functions.
+  """
+  pass
+
+
+def probe(initial_delay_secs: int=0,
+          timeout_secs: int=0,
+          period_secs: int=10,
+          success_threshold: int=1,
+          failure_threshold: int=3,
+          exec: Optional[ExecAction]=None,
+          http_get: Optional[HTTPGetAction]=None,
+          tcp_socket: Optional[TCPSocketAction]=None) -> Probe:
+  """Creates a :class:`Probe` for use with local_resource readiness checks.
+
+  Exactly one of exec, http_get, or tcp_socket must be specified.
+
+  Args:
+    initial_delay_secs: Number of seconds after the resource has started before the probe is
+      first initiated (default=0).
+    timeout_secs: Number of seconds after which probe execution is aborted and it is
+      considered to have failed (minimum vale is 1).
+    period_secs: How often in seconds to perform the probe (minimum value is 1).
+    success_threshold: Minimum number of consecutive successes for the result to be
+      considered successful after having failed (minimum value is 1).
+    failure_threshold: Minimum number of consecutive failures for the result to be
+      considered failing after having succeeded (minimum value is 1).
+    exec: Process execution handler to determine probe success.
+    http_get: HTTP GET handler to determine probe success.
+    tcp_socket: TCP socket connection handler to determine probe success.
+  """
+
+def exec_action(command: List[str]) -> ExecAction:
+  """Creates an :class:`ExecAction` for use with a :class:`Probe` that runs a command
+  to determine service readiness based on exit code.
+
+  Args:
+    command: Command with arguments to execute.
+  """
+  pass
+
+
+def http_get_action(host: str, port: int, scheme: str='http', path: str='') -> HTTPGetAction:
+  """Creates a :class:`HTTPGetAction` for use with a :class:`Probe` that performs an HTTP GET
+  request to determine service readiness based on response status code.
+
+  Args:
+    host: Hostname to use for HTTP request (defaults to localhost if not specified).
+    port: Port to use for HTTP request.
+    scheme: URI scheme to use for HTTP request, valid values are `http` and `https`.
+    path: URI path for HTTP reqeust.
+  """
+  pass
+
+
+def tcp_socket_action(host: str, port: int) -> TCPSocketAction:
+  """Creates a :class:`TCPSocketAction` for use with a :class:`Probe` that establishes a TCP
+  socket connection to determine service readiness.
+
+  Args:
+    host: Hostname to use for TCP socket connection (defaults to localhost if not specified).
+    port: Port to use for TCP socket connection.
+  """
+  pass

--- a/api/api.py
+++ b/api/api.py
@@ -1122,12 +1122,12 @@ def exec_action(command: List[str]) -> ExecAction:
   pass
 
 
-def http_get_action(host: str, port: int, scheme: str='http', path: str='') -> HTTPGetAction:
+def http_get_action(port: int, host: str='localhost', scheme: str='http', path: str='') -> HTTPGetAction:
   """Creates a :class:`HTTPGetAction` for use with a :class:`Probe` that performs an HTTP GET
   request to determine service readiness based on response status code.
 
   Args:
-    host: Hostname to use for HTTP request (defaults to localhost if not specified).
+    host: Hostname to use for HTTP request.
     port: Port to use for HTTP request.
     scheme: URI scheme to use for HTTP request, valid values are `http` and `https`.
     path: URI path for HTTP reqeust.
@@ -1135,12 +1135,12 @@ def http_get_action(host: str, port: int, scheme: str='http', path: str='') -> H
   pass
 
 
-def tcp_socket_action(host: str, port: int) -> TCPSocketAction:
+def tcp_socket_action(port: int, host: str='localhost') -> TCPSocketAction:
   """Creates a :class:`TCPSocketAction` for use with a :class:`Probe` that establishes a TCP
   socket connection to determine service readiness.
 
   Args:
-    host: Hostname to use for TCP socket connection (defaults to localhost if not specified).
+    host: Hostname to use for TCP socket connection.
     port: Port to use for TCP socket connection.
   """
   pass

--- a/docs/local_resource.md
+++ b/docs/local_resource.md
@@ -136,3 +136,26 @@ local_resource('custom-env',
                serve_cmd='./myserver', serve_env=serve_env,
                deps=['cmd/myserver'])
 ```
+
+## readiness_probe
+
+ Probes for local resources determine whether the `serve_cmd` is considered ready.
+ In addition to providing more accurate resource visibility in the Tilt UI, this ensures that Tilt waits for the probe to be successful before starting any dependent resources for the first time.
+ Readiness probes are optional; local resources without one are considered ready as soon as the process is started.
+
+ Local resource probes behave very similarly to Kubernetes readiness probes and support similar parameters to adjust the probing period, failure threshold, and more.
+ See the [`probe` API spec](api.html#api.probe) for all available options.
+
+ Probes can be an HTTP GET request ([`http_get_action`](api.html#api.http_get_action)), a TCP socket connection ([`tcp_socket_action`](api.html#api.tcp_socket_action)), or a custom program/script ([`exec_action`](api.html#api.exec_action)).
+
+You can configure a `local_resource` with an HTTP GET readiness probe for the `serve_cmd` as follows:
+ ```python
+local_resource(
+   "probe-example",
+   serve_cmd="./myserver --port=8001",
+   readiness_probe=probe(
+      period_secs=15,
+      http_get=http_get_action(port=8001, path="/health")
+   )
+)
+ ```

--- a/src/_data/api/classes.yaml
+++ b/src/_data/api/classes.yaml
@@ -1,7 +1,11 @@
 classes:
 - Blob
+- ExecAction
+- HTTPGetAction
 - K8sObjectID
 - Link
 - LiveUpdateStep
 - PortForward
+- Probe
+- TCPSocketAction
 - TriggerMode

--- a/src/_data/api/functions.yaml
+++ b/src/_data/api/functions.yaml
@@ -16,10 +16,12 @@ functions:
 - encode_json
 - encode_yaml
 - encode_yaml_stream
+- exec_action
 - fail
 - fall_back_on
 - filter_yaml
 - helm
+- http_get_action
 - include
 - k8s_context
 - k8s_kind
@@ -33,6 +35,7 @@ functions:
 - local
 - local_resource
 - port_forward
+- probe
 - read_file
 - read_json
 - read_yaml
@@ -43,6 +46,7 @@ functions:
 - set_team
 - struct
 - sync
+- tcp_socket_action
 - trigger_mode
 - update_settings
 - version_settings

--- a/src/_data/github.yml
+++ b/src/_data/github.yml
@@ -1,2 +1,2 @@
-stars: 4.0k
+stars: 4.1k
 href: https://github.com/tilt-dev/tilt

--- a/src/_includes/api/classes.html
+++ b/src/_includes/api/classes.html
@@ -33,6 +33,82 @@
            </p>
           </dd>
          </dl><dl class="class">
+          <dt id="api.ExecAction">
+           <em class="property">
+            class
+           </em>
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            ExecAction
+           </code>
+           <a class="headerlink" href="#api.ExecAction" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Specification for a command to execute that determines resource readiness.
+           </p>
+           <p>
+            For details, see the
+            <a class="reference internal" href="#api.probe" title="api.probe">
+             <code class="xref py py-func docutils literal notranslate">
+              <span class="pre">
+               probe()
+              </span>
+             </code>
+            </a>
+            and
+            <a class="reference internal" href="#api.exec_action" title="api.exec_action">
+             <code class="xref py py-func docutils literal notranslate">
+              <span class="pre">
+               exec_action()
+              </span>
+             </code>
+            </a>
+            functions.
+           </p>
+          </dd>
+         </dl><dl class="class">
+          <dt id="api.HTTPGetAction">
+           <em class="property">
+            class
+           </em>
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            HTTPGetAction
+           </code>
+           <a class="headerlink" href="#api.HTTPGetAction" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Specification for a HTTP GET request to perform that determines resource readiness.
+           </p>
+           <p>
+            For details, see the
+            <a class="reference internal" href="#api.probe" title="api.probe">
+             <code class="xref py py-func docutils literal notranslate">
+              <span class="pre">
+               probe()
+              </span>
+             </code>
+            </a>
+            and
+            <a class="reference internal" href="#api.http_get_action" title="api.http_get_action">
+             <code class="xref py py-func docutils literal notranslate">
+              <span class="pre">
+               http_get_action()
+              </span>
+             </code>
+            </a>
+            functions.
+           </p>
+          </dd>
+         </dl><dl class="class">
           <dt id="api.K8sObjectID">
            <em class="property">
             class
@@ -264,6 +340,74 @@
              </code>
             </a>
             method.
+           </p>
+          </dd>
+         </dl><dl class="class">
+          <dt id="api.Probe">
+           <em class="property">
+            class
+           </em>
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            Probe
+           </code>
+           <a class="headerlink" href="#api.Probe" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Specification for a resource readiness check.
+           </p>
+           <p>
+            For details, see the
+            <a class="reference internal" href="#api.probe" title="api.probe">
+             <code class="xref py py-meth docutils literal notranslate">
+              <span class="pre">
+               probe()
+              </span>
+             </code>
+            </a>
+            function.
+           </p>
+          </dd>
+         </dl><dl class="class">
+          <dt id="api.TCPSocketAction">
+           <em class="property">
+            class
+           </em>
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            TCPSocketAction
+           </code>
+           <a class="headerlink" href="#api.TCPSocketAction" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Specification for a TCP socket connection to perform that determines resource readiness.
+           </p>
+           <p>
+            For details, see the
+            <a class="reference internal" href="#api.probe" title="api.probe">
+             <code class="xref py py-func docutils literal notranslate">
+              <span class="pre">
+               probe()
+              </span>
+             </code>
+            </a>
+            and
+            <a class="reference internal" href="#api.tcp_socket_action" title="api.tcp_socket_action">
+             <code class="xref py py-func docutils literal notranslate">
+              <span class="pre">
+               tcp_socket_action()
+              </span>
+             </code>
+            </a>
+            functions.
            </p>
           </dd>
          </dl><dl class="class">

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -2884,6 +2884,91 @@ multiple YAML documents, separated by
            </table>
           </dd>
          </dl><dl class="function">
+          <dt id="api.exec_action">
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            exec_action
+           </code>
+           <span class="sig-paren">
+            (
+           </span>
+           <em>
+            command
+           </em>
+           <span class="sig-paren">
+            )
+           </span>
+           <a class="headerlink" href="#api.exec_action" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Creates an
+            <a class="reference internal" href="#api.ExecAction" title="api.ExecAction">
+             <code class="xref py py-class docutils literal notranslate">
+              <span class="pre">
+               ExecAction
+              </span>
+             </code>
+            </a>
+            for use with a
+            <a class="reference internal" href="#api.Probe" title="api.Probe">
+             <code class="xref py py-class docutils literal notranslate">
+              <span class="pre">
+               Probe
+              </span>
+             </code>
+            </a>
+            that runs a command
+to determine service readiness based on exit code.
+           </p>
+           <table class="docutils field-list" frame="void" rules="none">
+            <col class="field-name">
+            <col class="field-body">
+            <tbody valign="top">
+             <tr class="field-odd field">
+              <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <strong>
+                command
+               </strong>
+               (
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 List
+                </span>
+               </code>
+               [
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 str
+                </span>
+               </code>
+               ]) &#x2013; Command with arguments to execute.
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
+               Return type:
+              </th>
+              <td class="field-body">
+               <a class="reference internal" href="#api.ExecAction" title="api.ExecAction">
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  ExecAction
+                 </span>
+                </code>
+               </a>
+              </td>
+             </tr>
+            </tbody>
+           </table>
+          </dd>
+         </dl><dl class="function">
           <dt id="api.fail">
            <code class="descclassname">
            </code>
@@ -3546,6 +3631,147 @@ Chart directory is watched (See
                  <code class="xref py py-class docutils literal notranslate">
                   <span class="pre">
                    Blob
+                  </span>
+                 </code>
+                </a>
+               </p>
+              </td>
+             </tr>
+            </tbody>
+           </table>
+          </dd>
+         </dl><dl class="function">
+          <dt id="api.http_get_action">
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            http_get_action
+           </code>
+           <span class="sig-paren">
+            (
+           </span>
+           <em>
+            host
+           </em>
+           ,
+           <em>
+            port
+           </em>
+           ,
+           <em>
+            scheme=&apos;http&apos;
+           </em>
+           ,
+           <em>
+            path=&apos;&apos;
+           </em>
+           <span class="sig-paren">
+            )
+           </span>
+           <a class="headerlink" href="#api.http_get_action" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Creates a
+            <a class="reference internal" href="#api.HTTPGetAction" title="api.HTTPGetAction">
+             <code class="xref py py-class docutils literal notranslate">
+              <span class="pre">
+               HTTPGetAction
+              </span>
+             </code>
+            </a>
+            for use with a
+            <a class="reference internal" href="#api.Probe" title="api.Probe">
+             <code class="xref py py-class docutils literal notranslate">
+              <span class="pre">
+               Probe
+              </span>
+             </code>
+            </a>
+            that performs an HTTP GET
+request to determine service readiness based on response status code.
+           </p>
+           <table class="docutils field-list" frame="void" rules="none">
+            <col class="field-name">
+            <col class="field-body">
+            <tbody valign="top">
+             <tr class="field-odd field">
+              <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <ul class="first simple">
+                <li>
+                 <strong>
+                  host
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; Hostname to use for HTTP request (defaults to localhost if not specified).
+                </li>
+                <li>
+                 <strong>
+                  port
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   int
+                  </span>
+                 </code>
+                 ) &#x2013; Port to use for HTTP request.
+                </li>
+                <li>
+                 <strong>
+                  scheme
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; URI scheme to use for HTTP request, valid values are
+                 <cite>
+                  http
+                 </cite>
+                 and
+                 <cite>
+                  https
+                 </cite>
+                 .
+                </li>
+                <li>
+                 <strong>
+                  path
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; URI path for HTTP reqeust.
+                </li>
+               </ul>
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
+               Return type:
+              </th>
+              <td class="field-body">
+               <p class="first last">
+                <a class="reference internal" href="#api.HTTPGetAction" title="api.HTTPGetAction">
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   HTTPGetAction
                   </span>
                  </code>
                 </a>
@@ -6221,6 +6447,225 @@ a call to
            </table>
           </dd>
          </dl><dl class="function">
+          <dt id="api.probe">
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            probe
+           </code>
+           <span class="sig-paren">
+            (
+           </span>
+           <em>
+            initial_delay_secs=0
+           </em>
+           ,
+           <em>
+            timeout_secs=0
+           </em>
+           ,
+           <em>
+            period_secs=10
+           </em>
+           ,
+           <em>
+            success_threshold=1
+           </em>
+           ,
+           <em>
+            failure_threshold=3
+           </em>
+           ,
+           <em>
+            exec=None
+           </em>
+           ,
+           <em>
+            http_get=None
+           </em>
+           ,
+           <em>
+            tcp_socket=None
+           </em>
+           <span class="sig-paren">
+            )
+           </span>
+           <a class="headerlink" href="#api.probe" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Creates a
+            <a class="reference internal" href="#api.Probe" title="api.Probe">
+             <code class="xref py py-class docutils literal notranslate">
+              <span class="pre">
+               Probe
+              </span>
+             </code>
+            </a>
+            for use with local_resource readiness checks.
+           </p>
+           <p>
+            Exactly one of exec, http_get, or tcp_socket must be specified.
+           </p>
+           <table class="docutils field-list" frame="void" rules="none">
+            <col class="field-name">
+            <col class="field-body">
+            <tbody valign="top">
+             <tr class="field-odd field">
+              <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <ul class="first simple">
+                <li>
+                 <strong>
+                  initial_delay_secs
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   int
+                  </span>
+                 </code>
+                 ) &#x2013; Number of seconds after the resource has started before the probe is
+first initiated (default=0).
+                </li>
+                <li>
+                 <strong>
+                  timeout_secs
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   int
+                  </span>
+                 </code>
+                 ) &#x2013; Number of seconds after which probe execution is aborted and it is
+considered to have failed (minimum vale is 1).
+                </li>
+                <li>
+                 <strong>
+                  period_secs
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   int
+                  </span>
+                 </code>
+                 ) &#x2013; How often in seconds to perform the probe (minimum value is 1).
+                </li>
+                <li>
+                 <strong>
+                  success_threshold
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   int
+                  </span>
+                 </code>
+                 ) &#x2013; Minimum number of consecutive successes for the result to be
+considered successful after having failed (minimum value is 1).
+                </li>
+                <li>
+                 <strong>
+                  failure_threshold
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   int
+                  </span>
+                 </code>
+                 ) &#x2013; Minimum number of consecutive failures for the result to be
+considered failing after having succeeded (minimum value is 1).
+                </li>
+                <li>
+                 <strong>
+                  exec
+                 </strong>
+                 (
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Optional
+                  </span>
+                 </code>
+                 [
+                 <a class="reference internal" href="#api.ExecAction" title="api.ExecAction">
+                  <code class="xref py py-class docutils literal notranslate">
+                   <span class="pre">
+                    ExecAction
+                   </span>
+                  </code>
+                 </a>
+                 ]) &#x2013; Process execution handler to determine probe success.
+                </li>
+                <li>
+                 <strong>
+                  http_get
+                 </strong>
+                 (
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Optional
+                  </span>
+                 </code>
+                 [
+                 <a class="reference internal" href="#api.HTTPGetAction" title="api.HTTPGetAction">
+                  <code class="xref py py-class docutils literal notranslate">
+                   <span class="pre">
+                    HTTPGetAction
+                   </span>
+                  </code>
+                 </a>
+                 ]) &#x2013; HTTP GET handler to determine probe success.
+                </li>
+                <li>
+                 <strong>
+                  tcp_socket
+                 </strong>
+                 (
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Optional
+                  </span>
+                 </code>
+                 [
+                 <a class="reference internal" href="#api.TCPSocketAction" title="api.TCPSocketAction">
+                  <code class="xref py py-class docutils literal notranslate">
+                   <span class="pre">
+                    TCPSocketAction
+                   </span>
+                  </code>
+                 </a>
+                 ]) &#x2013; TCP socket connection handler to determine probe success.
+                </li>
+               </ul>
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
+               Return type:
+              </th>
+              <td class="field-body">
+               <p class="first last">
+                <a class="reference internal" href="#api.Probe" title="api.Probe">
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   Probe
+                  </span>
+                 </code>
+                </a>
+               </p>
+              </td>
+             </tr>
+            </tbody>
+           </table>
+          </dd>
+         </dl><dl class="function">
           <dt id="api.read_file">
            <code class="descclassname">
            </code>
@@ -7358,6 +7803,107 @@ Can be a file (in which case just that file will be synced) or directory (in whi
                  <code class="xref py py-class docutils literal notranslate">
                   <span class="pre">
                    LiveUpdateStep
+                  </span>
+                 </code>
+                </a>
+               </p>
+              </td>
+             </tr>
+            </tbody>
+           </table>
+          </dd>
+         </dl><dl class="function">
+          <dt id="api.tcp_socket_action">
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            tcp_socket_action
+           </code>
+           <span class="sig-paren">
+            (
+           </span>
+           <em>
+            host
+           </em>
+           ,
+           <em>
+            port
+           </em>
+           <span class="sig-paren">
+            )
+           </span>
+           <a class="headerlink" href="#api.tcp_socket_action" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Creates a
+            <a class="reference internal" href="#api.TCPSocketAction" title="api.TCPSocketAction">
+             <code class="xref py py-class docutils literal notranslate">
+              <span class="pre">
+               TCPSocketAction
+              </span>
+             </code>
+            </a>
+            for use with a
+            <a class="reference internal" href="#api.Probe" title="api.Probe">
+             <code class="xref py py-class docutils literal notranslate">
+              <span class="pre">
+               Probe
+              </span>
+             </code>
+            </a>
+            that establishes a TCP
+socket connection to determine service readiness.
+           </p>
+           <table class="docutils field-list" frame="void" rules="none">
+            <col class="field-name">
+            <col class="field-body">
+            <tbody valign="top">
+             <tr class="field-odd field">
+              <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <ul class="first simple">
+                <li>
+                 <strong>
+                  host
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; Hostname to use for TCP socket connection (defaults to localhost if not specified).
+                </li>
+                <li>
+                 <strong>
+                  port
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   int
+                  </span>
+                 </code>
+                 ) &#x2013; Port to use for TCP socket connection.
+                </li>
+               </ul>
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
+               Return type:
+              </th>
+              <td class="field-body">
+               <p class="first last">
+                <a class="reference internal" href="#api.TCPSocketAction" title="api.TCPSocketAction">
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   TCPSocketAction
                   </span>
                  </code>
                 </a>

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -3651,11 +3651,11 @@ Chart directory is watched (See
             (
            </span>
            <em>
-            host
+            port
            </em>
            ,
            <em>
-            port
+            host=&apos;localhost&apos;
            </em>
            ,
            <em>
@@ -3713,7 +3713,7 @@ request to determine service readiness based on response status code.
                    str
                   </span>
                  </code>
-                 ) &#x2013; Hostname to use for HTTP request (defaults to localhost if not specified).
+                 ) &#x2013; Hostname to use for HTTP request.
                 </li>
                 <li>
                  <strong>
@@ -7823,11 +7823,11 @@ Can be a file (in which case just that file will be synced) or directory (in whi
             (
            </span>
            <em>
-            host
+            port
            </em>
            ,
            <em>
-            port
+            host=&apos;localhost&apos;
            </em>
            <span class="sig-paren">
             )
@@ -7877,7 +7877,7 @@ socket connection to determine service readiness.
                    str
                   </span>
                  </code>
-                 ) &#x2013; Hostname to use for TCP socket connection (defaults to localhost if not specified).
+                 ) &#x2013; Hostname to use for TCP socket connection.
                 </li>
                 <li>
                  <strong>


### PR DESCRIPTION
## Local Resource docs : `readiness_probe` section
<img width="780" alt="Screen Shot 2021-01-27 at 11 07 46 AM" src="https://user-images.githubusercontent.com/841263/106018806-eeec8580-608f-11eb-9f58-2690e16ca1b9.png">

## API Reference
### `Probe` + `probe()`
<img width="1208" alt="Screen Shot 2021-01-27 at 11 08 57 AM" src="https://user-images.githubusercontent.com/841263/106019404-9d90c600-6090-11eb-9d41-847bd53cc832.png">

### `ExecAction` + `exec_action()`
<img width="1194" alt="Screen Shot 2021-01-27 at 11 09 25 AM" src="https://user-images.githubusercontent.com/841263/106019434-a7b2c480-6090-11eb-8ac0-b8ec3193143c.png">

### `HTTPGetAction` + `http_get_action()`
(⚠️ This screenshot is slightly outdated, arg order changed to `port: int, host: str='localhost'`)
<img width="1265" alt="Screen Shot 2021-01-27 at 11 09 32 AM" src="https://user-images.githubusercontent.com/841263/106019558-c6b15680-6090-11eb-8430-43f5b4d18482.png">

### `TCPSocketAction` + `tcp_socket_action()`
(⚠️ This screenshot is slightly outdated, arg order changed to `port: int, host: str='localhost'`)
<img width="1295" alt="Screen Shot 2021-01-27 at 11 09 45 AM" src="https://user-images.githubusercontent.com/841263/106019596-d16beb80-6090-11eb-8203-12d0e6a493b5.png">