### PR TITLE
docs: fix default value for disable in docker_prune_settings

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -939,7 +939,7 @@ def disable_snapshots() -> None:
     ensures a pretty high bar of intent.
     """
 
-def docker_prune_settings(disable: bool=True, max_age_mins: int=360,
+def docker_prune_settings(disable: bool=False, max_age_mins: int=360,
                           num_builds: int=0, interval_hrs: int=1, keep_recent: int=2) -> None:
   """
   Configures Tilt's Docker Pruner, which runs occasionally in the background and prunes Docker images associated

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -2303,7 +2303,7 @@ the DockerImage ref).
             (
            </span>
            <em>
-            disable=True
+            disable=False
            </em>
            ,
            <em>


### PR DESCRIPTION
The default here is `False` (i.e. enable Docker prune); the docs
were incorrect.