### PR TITLE
Remove brew install from upgrade docs

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -32,7 +32,6 @@ Other Upgrade Methods
 
 ```
 $ brew update && brew upgrade tilt-dev/tap/tilt
-$ brew install tilt-dev/tap/tilt
 ```
 
 ## Scoop


### PR DESCRIPTION
Hello!

I believe that `brew install` is not required when upgrading tilt using homebrew because `brew upgrade tilt-dev/tap/tilt` already installs the latest version.

I get this warning when I run `brew install` (after running `brew upgrade`):

$ brew install tilt-dev/tap/tilt
Warning: tilt-dev/tap/tilt 0.19.5 is already installed and up-to-date.
To reinstall 0.19.5, run:
  brew reinstall tilt