### PR TITLE
site: replace enterprise page with a 'tilt shift' page

### DIFF
--- a/src/_data/footer.yml
+++ b/src/_data/footer.yml
@@ -1,5 +1,5 @@
-- name: Enterprise
-  href: enterprise
+- name: Schedule a Guide
+  href: liftoff
   primary: true
   landingurl: true
 - name: Docs

--- a/src/_data/github.yml
+++ b/src/_data/github.yml
@@ -1,2 +1,2 @@
-stars: 4.2k
+stars: 4.3k
 href: https://github.com/tilt-dev/tilt

--- a/src/_data/header.yml
+++ b/src/_data/header.yml
@@ -1,5 +1,5 @@
-- name: Enterprise
-  href: enterprise
+- name: Schedule a Guide
+  href: liftoff
   primary: true
   landingurl: true
 - name: Docs

--- a/src/_includes/index_cta.html
+++ b/src/_includes/index_cta.html
@@ -1,7 +1,7 @@
 <section class="modal" data-modal="one">
   <div class="modal-calendly">
     <h2 class="modal-title">
-      Schedule a Demo
+      Schedule a Guide
     </h2>
     <button class="modal-close">{% svg assets/svg/x.svg %}</button>
     <div class="modal-content">
@@ -11,12 +11,17 @@
       ></div>
       <div class="modal-content__text">
         <p class="modal-heroText">
-          Schedule a 30 minute conversation with a Tilt team member.
+          Get help with your Tilt Liftoff.
         </p>
         <p>
-          We will demo Tilt, discuss your challenges, answer your questions, and
-          figure out how we can help supercharge your workflow.
+          Our Tilt Liftoff program lasts 6 weeks and is completely free for teams that are committed to trying out Tilt.
         </p>
+        <ul>
+          <li>A weekly meeting with Tilters to guide you through onboarding.</li>
+          <li>A dedicated Slack channel with Tilt engineers.</li>
+          <li>Pairing sessions to help you draft and evolve your Tiltfile.</li>
+          <li>Help from our content strategists on how to talk about and teach Tilt.</li>
+        </ul>
         <p class="modal-content--highlight">
           Don't want to schedule time right now? We would love to call you back.
         </p>
@@ -26,7 +31,7 @@
   </div>
   <div class="modal-callback">
     <h2 class="modal-title">
-      Schedule a Demo
+      Schedule a Guide
     </h2>
     <button class="modal-close">{% svg assets/svg/x.svg %}</button>
     <div class="modal-content">
@@ -72,16 +77,21 @@
 
       <div class="modal-content__text">
         <p class="modal-heroText">
-          Schedule a 30 minute conversation with a Tilt team member.
+          Get help with your Tilt Liftoff.
         </p>
         <p>
-          We will demo Tilt, discuss your challenges, answer your questions, and
-          figure out how we can help supercharge your workflow.
+          Our Tilt Liftoff program lasts 6 weeks and is completely free for teams that are committed to trying out Tilt.
         </p>
+        <ul>
+          <li>A weekly meeting with Tilters to guide you through onboarding.</li>
+          <li>A dedicated Slack channel with Tilt engineers.</li>
+          <li>Pairing sessions to help you draft and evolve your Tiltfile.</li>
+          <li>Help from our content strategists on how to talk about and teach Tilt.</li>
+        </ul>
         <p class="modal-content--highlight">
           Don't want a callback? Schedule a time directly.
         </p>
-        <button class="Home-cta-button modal-switchButton">Schedule a Demo</button>
+        <button class="Home-cta-button modal-switchButton">Schedule a Guide</button>
       </div>
     </div>
   </div>
@@ -94,9 +104,9 @@
       class="popup-trigger Home-cta-button Home-cta-button--primary gtm-button-schedule-a-demo"
       data-popup-trigger="one"
     >
-      Schedule a Demo
+      Schedule a Guide
     </button>
-    <small class="Home-cta-option-text">for your work team</small>
+    <small class="Home-cta-option-text">to help with your Tilt Liftoff</small>
   </div>
   <div class="Home-cta-option">
     <a

--- a/src/liftoff.md
+++ b/src/liftoff.md
@@ -1,0 +1,103 @@
+---
+layout: enterprise
+title: Schedule a Guide
+permalink: /liftoff
+has_calendly: true
+---
+
+<h2 class="Enterprise-heroTitle">Get Help with your Tilt Liftoff</h2>
+<section class="Enterprise-hero">
+  <div class="Enterprise-hero-text">
+    <p class="Enterprise-hero-text-subhead">
+      Our Tilt Liftoff program lasts 6 weeks and is completely free for teams that are committed to trying out Tilt.
+    </p>
+    <div class="Enterprise-hero-text-detail">
+      <ul>
+        <li>A weekly meeting with Tilters to guide you through onboarding.</li>
+        <li>A dedicated Slack channel with Tilt engineers.</li>
+        <li>Pairing sessions to help you draft and evolve your Tiltfile.</li>
+        <li>Help from our content strategists on how to talk about and teach Tilt.</li>
+      </ul>
+      {% svg assets/svg/illustration-enterprise.svg %}
+    </div>
+  </div>
+  <div class="Enterprise-hero-cta">
+    <h4 class="Enterprise-hero-cta-title">Schedule a Guide</h4>
+    <div class="calendly-inline-widget" data-url="https://calendly.com/d/mf62-vthy/tilt-onboarding-call?hide_event_type_details=1"></div>
+  </div>
+</section>
+
+<h3 class="Enterprise-sectionHeading">The Tilt Perspective</h3>
+<ul class="Enterprise-featureList">
+  <li>
+    <h4 class="Enterprise-featureItem-title">Orderly Orchestration</h4>
+    <p class="Enterprise-featureItem-text">Our engine starts the whole app and runs automated rebuilds as you edit in your IDE. Get a continuous feedback loop with your logs, broken builds, runtime errors. </p>
+  </li>
+  <li>
+    <h4 class="Enterprise-featureItem-title">Built-In Best Practices</h4>
+    <p class="Enterprise-featureItem-text">
+      We’ve codified best practices to give your team a common development path and ensure reproducibility. Anyone can start the app – new hires just `tilt up`.
+    </p>
+  </li>
+  <li>
+    <h4 class="Enterprise-featureItem-title">Painless Onboarding</h4>
+    <p class="Enterprise-featureItem-text">
+      We made Tilt platform agnostic, versatile and easy to configure, because we know every setup is different. 
+      We'll pair with you to integrate Tilt in stages for a smooth transition.
+    </p>
+  </li>
+</ul>
+
+{% include index_cta.html %}
+
+<script async src="/assets/js/cta.js"></script>
+
+<h3 class="Home-sectionHeading">Learn More</h3>
+<section class="Home-resources">
+  <ul class="Home-resources-list">
+    <li class="Home-resources-listItem">
+      <div class="Home-resources-listItem-text">
+        <h4 class="Home-subsectionHeading Home-subsectionHeading--resources">
+          {% svg assets/svg/social-slack.svg class="Home-resources-svg" %}
+          Chat with Us
+        </h4>
+        <p>Find us in the #tilt channel of the official Kubernetes Slack. We’re there Mon-Fri EST business hours. We don’t bite.</p>
+      </div>
+      <a href="https://slack.k8s.io/" class="Home-resources-link">Get Your Invite</a>
+    </li>
+    <li class="Home-resources-listItem">
+      <div class="Home-resources-listItem-text">
+        <h4 class="Home-subsectionHeading Home-subsectionHeading--resources">
+          {% svg assets/svg/resources-contact.svg class="Home-resources-svg" %}
+          Email us
+        </h4>
+        <p>Have questions or feature requests for Tilt? Want to use it for your company? Just want to say hi? We love hearing from you!</p>
+      </div>
+      <a href="mailto:hi@tilt.dev" class="Home-resources-link">hi@tilt.dev</a>
+    </li>
+    <li class="Home-resources-listItem">
+      <div class="Home-resources-listItem-text">
+        <h4 class="Home-subsectionHeading Home-subsectionHeading--resources">
+          {% svg assets/svg/resources-mailing-list.svg class="Home-resources-svg" %}
+          Our Mailing List
+        </h4>
+        <p>Keep up with Multi-Service Development and all things Tilt.</p>
+      </div>
+      <div class="Home-resources-listItem-cta">
+        <form action="https://www.getdrip.com/forms/507796156/submissions" method="post" data-drip-embedded-form="507796156">
+          <label for="drip-email" class="Home-resources-label">Your Email</label>
+          <input class="Home-resources-input" type="email" id="drip-email" name="fields[email]" value="" placeholder="me@company.com" />
+          <button class="Home-resources-button" type="submit" data-drip-attribute="sign-up-button">
+            Subscribe
+          </button>
+          <div style="display: none;" aria-hidden="true">
+            <label for="website">Website</label><br />
+            <input type="text" id="website" name="website" tabindex="-1" autocomplete="false" value="" />
+          </div>
+        </form>
+      </div>
+    </li>
+  </ul>
+</section>
+
+


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/cta:

d2aae90e2af2b093f8a473520f045aec92338266 (2021-05-12 18:22:10 -0400)
site: replace enterprise page with a 'tilt shift' page

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics