### PR TITLE
blog: use find instead of ls

### DIFF
--- a/blog/_posts/2021-05-18-entr-the-dragon.md
+++ b/blog/_posts/2021-05-18-entr-the-dragon.md
@@ -68,10 +68,11 @@ run `entr`.
 For day-to-day running of unit tests, something like
 
 ```
-ls pkg/model | entr go test ./pkg/model/...
+find pkg/model | entr go test ./pkg/model/...
 ```
 
-does what I need.
+does what I need. `find pkg/model` lists all tests in that directory. `entr`
+reruns the test when any of them change.
 
 ### Example #2: reload a server
 
@@ -98,7 +99,7 @@ to build `entr`-like reloading.
 Let's reimplement our test re-runner above on the Tilt API.
 
 ```
-ls pkg/model | entr go test ./pkg/model/...
+find pkg/model | entr go test ./pkg/model/...
 ```
 
 First, start a Tilt server for your project's dev environment:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/entr2:

31619e4b02b64989c465de5a54af24c2f1a30715 (2021-05-18 12:53:31 -0400)
blog: use find instead of ls

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics