### PR TITLE
docs: remove auto_init=False / TRIGGER_MODE_AUTO restrictions

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -429,9 +429,8 @@ def k8s_resource(workload: str = "", new_name: str = "",
       resource with name ``new_name``. If an object selector matches more than
       one Kubernetes object, or matches an object already associated with a
       resource, ``k8s_resource`` raises an error.
-    auto_init: whether this resource runs on ``tilt up``. Defaults to ``True``.
-      Note that ``auto_init=False`` is only compatible with
-      ``trigger_mode=TRIGGER_MODE_MANUAL``.
+    auto_init: whether this resource runs on ``tilt up``. Defaults to ``True``. For more info, see the
+      `Manual Update Control docs <manual_update_control.html>`_.
     pod_readiness: Possible values: 'ignore', 'wait'. Controls whether Tilt waits for
       pods to be ready before the resource is considered healthy (and dependencies
       can start building). By default, Tilt will wait for pods to be ready if it
@@ -964,7 +963,8 @@ def local_resource(name: str, cmd: Union[str, List[str]],
     resource_deps: a list of resources on which this resource depends.
       See the `Resource Dependencies docs <resource_dependencies.html>`_.
     ignore: set of file patterns that will be ignored. Ignored files will not trigger runs. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns will be evaluated relative to the Tiltfile.
-    auto_init: whether this resource runs on ``tilt up``. Defaults to ``True``. Note that ``auto_init=False`` is only compatible with ``trigger_mode=TRIGGER_MODE_MANUAL``.
+    auto_init: whether this resource runs on ``tilt up``. Defaults to ``True``. For more info, see the
+      `Manual Update Control docs <manual_update_control.html>`_.
     serve_cmd: Tilt will run this command on update and expect it to not exit.
       Executed with ``sh -c`` on macOS/Linux, or ``cmd /S /C`` on Windows.
     cmd_bat: The command to run, expressed as a Windows batch command executed

--- a/blog/_posts/2019-11-15-local-resource.md
+++ b/blog/_posts/2019-11-15-local-resource.md
@@ -127,7 +127,7 @@ either `TRIGGER_MODE_AUTO` (the default), or `TRIGGER_MODE_MANUAL`. (A manual
 resource detects changes to its deps, but doesn't automatically update---rather,
 it displays a "ready for update" icon in the Web UI for the user to click at their
 leisure. For more on trigger mode, [see the docs](https://docs.tilt.dev/manual_update_control.html).)
-Manual mode may be especially useful for local resources that you only want to run occasionally. 
+Manual mode may be especially useful for local resources that you only want to run occasionally.
 
 By default, a local resource will run on startup. To disable this behavior, put the
 resource in `TRIGGER_MODE_MANUAL` and specify `auto_init=False`:
@@ -136,10 +136,6 @@ local_resource('blow-away-pods', cmd='kubectl delete pods --all',
     trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False
 )
 ```
-
-(`auto_init=False` is currently only compatible with `TRIGGER_MODE_MANUAL`. If
-you'd like a local resource that runs automatically in response to file changes
-but does NOT run on `tilt up`, [let us know](https://tilt.dev/contact).)
 
 ### Mix and match manual and automatic
 Note that you can mix and match manual and automatic runs as you like. Say you

--- a/docs/local_resource.md
+++ b/docs/local_resource.md
@@ -73,19 +73,17 @@ but do not write.
 
 ## auto_init
 
-By default, a local resource will run on startup. To disable this behavior, put the
-resource in `TRIGGER_MODE_MANUAL` and specify `auto_init=False`:
+By default, a local resource will run on startup. To disable this behavior, specify `auto_init=False`:
 ```python
-local_resource('reset-db', cmd='reset_db.sh',
-    trigger_mode=TRIGGER_MODE_MANUAL, auto_init=False
-)
+local_resource('reset-db', cmd='reset_db.sh', auto_init=False)
 ```
 
-For more on trigger mode, [see the docs](https://docs.tilt.dev/manual_update_control.html).
+You can combine this with `trigger_mode=TRIGGER_MODE_MANUAL` (so the resource only runs when
+explicitly triggered) or `trigger_mode=TRIGGER_MODE_AUTO` (so that the resource does not run
+on "tilt up" but will run if any of its file dependencies are changed -- this can be
+useful for tests, for example).
 
-`auto_init=False` is currently only compatible with `TRIGGER_MODE_MANUAL`. If
-you'd like a local resource that runs automatically in response to file changes
-but does NOT run on `tilt up`, [let us know](https://tilt.dev/contact).
+For more on trigger mode, [see the docs](https://docs.tilt.dev/manual_update_control.html).
 
 ## serve_cmd
 

--- a/docs/manual_update_control.md
+++ b/docs/manual_update_control.md
@@ -16,12 +16,13 @@ There's another way of doing things: `TriggerMode: Manual`. Tilt will still moni
 You can change the trigger mode(s) of your resources in your Tiltfile in two different ways:
 
 1. Functions that configure resources ([`k8s_resource()`](/api.html#api.k8s_resource), [`dc_resource()`](/api.html#api.dc_resource), [`local_resource()`](/api.html#api.local_resource)) have an optional arg, `trigger_mode`; for that specific resource, you can pass either `TRIGGER_MODE_AUTO` or `TRIGGER_MODE_MANUAL`.
-2. if you want to adjust all of your resource at once, call the top-level function [`trigger_mode()`](/api.html#api.trigger_mode) with one of those two constants. This sets the _default trigger mode for all manifests_. (You can still use `k8s_resource()` to set the trigger mode for individual manifests.)
+2. If you want to adjust all of your resources at once, call the top-level function [`trigger_mode()`](/api.html#api.trigger_mode) with one of those two constants. This sets the _default trigger mode for all resources_. (You can still use `k8s_resource()` to set the trigger mode for a specific resource.)
 
 Here are some examples:
 ```python
 ...
-k8s_resource('snack')  # TriggerMode = Auto by default
+# TriggerMode = Auto by default
+k8s_resource('snack')
 ```
 
 ```python
@@ -46,3 +47,12 @@ k8s_resource('bar', trigger_mode=TRIGGER_MODE_AUTO)
 </div>
 
 When you make changes to "snack", instead of them being automatically applied, Tilt will simply indicate unapplied changes by the asterisk to the right of `snack` in the sidebar. It will not automatically apply those changes. Instead, it will wait until you click the apply button to the left of `snack`.
+
+## Auto Init
+TriggerMode can be combined with the `auto_init` argument on [`k8s_resource()`](/api.html#api.k8s_resource) and [`local_resource()`](/api.html#api.local_resource) for even more fine-grained control.
+
+To configure a resource to _only_ run when explicitly triggered from the UI, set `auto_init=False` and `trigger_mode=TRIGGER_MODE_MANUAL`. It will not run on start nor when files are changed.
+
+To configure a resource that does _not_ run at start, but still runs whenever a file dependency is changed,
+set `auto_init=False` and `trigger_mode=TRIGGER_MODE_AUTO`. This can be useful for tasks like linting or
+executing tests automatically, for example.

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -4728,35 +4728,29 @@ resource,
                    bool
                   </span>
                  </code>
-                 ) &#x2013; whether this resource runs on
-                 <code class="docutils literal notranslate">
-                  <span class="pre">
-                   tilt
-                  </span>
-                  <span class="pre">
-                   up
-                  </span>
-                 </code>
-                 . Defaults to
-                 <code class="docutils literal notranslate">
-                  <span class="pre">
-                   True
-                  </span>
-                 </code>
-                 .
-Note that
-                 <code class="docutils literal notranslate">
-                  <span class="pre">
-                   auto_init=False
-                  </span>
-                 </code>
-                 is only compatible with
-                 <code class="docutils literal notranslate">
-                  <span class="pre">
-                   trigger_mode=TRIGGER_MODE_MANUAL
-                  </span>
-                 </code>
-                 .
+                 ) &#x2013;
+                 <p>
+                  whether this resource runs on
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    tilt
+                   </span>
+                   <span class="pre">
+                    up
+                   </span>
+                  </code>
+                  . Defaults to
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    True
+                   </span>
+                  </code>
+                  . For more info, see the
+                  <a class="reference external" href="manual_update_control.html">
+                   Manual Update Control docs
+                  </a>
+                  .
+                 </p>
                 </li>
                 <li>
                  <strong>
@@ -6030,34 +6024,29 @@ See the
                    bool
                   </span>
                  </code>
-                 ) &#x2013; whether this resource runs on
-                 <code class="docutils literal notranslate">
-                  <span class="pre">
-                   tilt
-                  </span>
-                  <span class="pre">
-                   up
-                  </span>
-                 </code>
-                 . Defaults to
-                 <code class="docutils literal notranslate">
-                  <span class="pre">
-                   True
-                  </span>
-                 </code>
-                 . Note that
-                 <code class="docutils literal notranslate">
-                  <span class="pre">
-                   auto_init=False
-                  </span>
-                 </code>
-                 is only compatible with
-                 <code class="docutils literal notranslate">
-                  <span class="pre">
-                   trigger_mode=TRIGGER_MODE_MANUAL
-                  </span>
-                 </code>
-                 .
+                 ) &#x2013;
+                 <p>
+                  whether this resource runs on
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    tilt
+                   </span>
+                   <span class="pre">
+                    up
+                   </span>
+                  </code>
+                  . Defaults to
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    True
+                   </span>
+                  </code>
+                  . For more info, see the
+                  <a class="reference external" href="manual_update_control.html">
+                   Manual Update Control docs
+                  </a>
+                  .
+                 </p>
                 </li>
                 <li>
                  <strong>


### PR DESCRIPTION
Previously, you could not have a resource that had `auto_init=False`
with `trigger_mode=TRIGGER_MODE_AUTO`. This restriction was lifted
in v0.19.1 a while back by https://github.com/tilt-dev/tilt/pull/4292.

This removes mention of the restriction from the docs including
retconning a blog post from 2019.