### PR TITLE
docs: clarify watch behavior for listdir & watch_file

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -573,6 +573,8 @@ def read_file(file_path: str, default: str = None) -> Blob:
 def watch_file(file_path: str) -> None:
   """Watches a file. If the file is changed a re-exectution of the Tiltfile is triggered.
 
+  If the path is a directory, its contents will be recursively watched.
+
   Args:
     file_path: Path to the file locally (absolute, or relative to the location of the Tiltfile)."""
 
@@ -610,9 +612,14 @@ def blob(contents: str) -> Blob:
   pass
 
 def listdir(directory: str, recursive: bool = False) -> List[str]:
-  """Returns all the files at the top level of the provided directory. If ``recursive`` is set to True, returns all files that are inside of the provided directory, recursively.
+  """Returns all the files of the provided directory.
 
-  Directory is watched (See ``watch_file``)."""
+  If ``rescursive`` is set to ``True``, the directory's contents will be recursively watched, and a change to any file will trigger a re-execution of the Tiltfile.
+
+  Args:
+    directory: Path to the directory locally (absolute, or relative to the location of the Tiltfile).
+    recursive: Walk the given directory tree recusrively and return all files in it; additionally, recursively watch for changes in the directory tree.
+  """
   pass
 
 def k8s_kind(kind: str, api_version: str=None, *, image_json_path: Union[str, List[str]]=[], image_object_json_path: Dict=None, pod_readiness: str=""):

--- a/api/api.py
+++ b/api/api.py
@@ -618,7 +618,7 @@ def listdir(directory: str, recursive: bool = False) -> List[str]:
 
   Args:
     directory: Path to the directory locally (absolute, or relative to the location of the Tiltfile).
-    recursive: Walk the given directory tree recusrively and return all files in it; additionally, recursively watch for changes in the directory tree.
+    recursive: Walk the given directory tree recursively and return all files in it; additionally, recursively watch for changes in the directory tree.
   """
   pass
 

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -5254,7 +5254,7 @@ uses kubectl&#x2019;s kustomize. See
                    bool
                   </span>
                  </code>
-                 ) &#x2013; Walk the given directory tree recusrively and return all files in it; additionally, recursively watch for changes in the directory tree.
+                 ) &#x2013; Walk the given directory tree recursively and return all files in it; additionally, recursively watch for changes in the directory tree.
                 </li>
                </ul>
               </td>

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -5205,22 +5205,22 @@ uses kubectl&#x2019;s kustomize. See
           </dt>
           <dd>
            <p>
-            Returns all the files at the top level of the provided directory. If
-            <code class="docutils literal notranslate">
-             <span class="pre">
-              recursive
-             </span>
-            </code>
-            is set to True, returns all files that are inside of the provided directory, recursively.
+            Returns all the files of the provided directory.
            </p>
            <p>
-            Directory is watched (See
+            If
             <code class="docutils literal notranslate">
              <span class="pre">
-              watch_file
+              rescursive
              </span>
             </code>
-            ).
+            is set to
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              True
+             </span>
+            </code>
+            , the directory&#x2019;s contents will be recursively watched, and a change to any file will trigger a re-execution of the Tiltfile.
            </p>
            <table class="docutils field-list" frame="void" rules="none">
             <col class="field-name">
@@ -5228,21 +5228,56 @@ uses kubectl&#x2019;s kustomize. See
             <tbody valign="top">
              <tr class="field-odd field">
               <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <ul class="first simple">
+                <li>
+                 <strong>
+                  directory
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; Path to the directory locally (absolute, or relative to the location of the Tiltfile).
+                </li>
+                <li>
+                 <strong>
+                  recursive
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   bool
+                  </span>
+                 </code>
+                 ) &#x2013; Walk the given directory tree recusrively and return all files in it; additionally, recursively watch for changes in the directory tree.
+                </li>
+               </ul>
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
                Return type:
               </th>
               <td class="field-body">
-               <code class="xref py py-class docutils literal notranslate">
-                <span class="pre">
-                 List
-                </span>
-               </code>
-               [
-               <code class="xref py py-class docutils literal notranslate">
-                <span class="pre">
-                 str
-                </span>
-               </code>
-               ]
+               <p class="first last">
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]
+               </p>
               </td>
              </tr>
             </tbody>
@@ -8495,6 +8530,9 @@ Examples:
           <dd>
            <p>
             Watches a file. If the file is changed a re-exectution of the Tiltfile is triggered.
+           </p>
+           <p>
+            If the path is a directory, its contents will be recursively watched.
            </p>
            <table class="docutils field-list" frame="void" rules="none">
             <col class="field-name">


### PR DESCRIPTION
* `watch_file` can (recursively) watch directories despite its
  name

* `listdir` _only_ watches if `recursive=True`; otherwise, it
  just returns a listing of the top-level directory but does
  not add a watch