### PR TITLE
blog: add execution clarification for uibutton

### DIFF
--- a/blog/_posts/2021-06-21-uibutton.md
+++ b/blog/_posts/2021-06-21-uibutton.md
@@ -25,7 +25,7 @@ This might be a command to reset the dev database to a clean slate, an artisanal
 
 Whatever it is, having a button at the ready on the resource in Tilt beats tapping up repeatedly to cycle through terminal history looking for that magic command a co-worker sent via Slack six months ago.
 
-To add a button to a resource, we can use the [uibutton extension](https://github.com/tilt-dev/tilt-extensions/tree/master/uibutton):
+To add a button to a resource, we can use the [uibutton extension][uibutton-ext]:
 ```python
 load('ext://uibutton', 'cmd_button')
 
@@ -38,5 +38,11 @@ cmd_button(name='lint',
 ![custom button in Tilt UI](/assets/images/uibutton/button-example.gif)
 
 When running `tilt up`, our new "lint" button shows up on the `frontend` resource and the command output gets interspersed with the rest of the resource logs.
+The command is executed on the host running `tilt up` (similar to `local_resource`).
 
-We are just scratching the surface of dashboard customization so that you can fully personalize Tilt to your workflow. [Let us know](https://docs.tilt.dev/#community) how you use custom buttons in your project!
+See the [uibutton extension][uibutton-ext] for more detailed usage and complete API reference.
+
+We are just scratching the surface of dashboard customization so that you can fully personalize Tilt to your workflow.
+[Let us know](https://docs.tilt.dev/#community) how you use custom buttons in your project!
+
+[uibutton-ext]: https://github.com/tilt-dev/tilt-extensions/tree/master/uibutton


### PR DESCRIPTION
Was asked about this on Twitter - blog post is vague here! (The
extension docs also didn't do a great job of clarifying this and
are being updated too.)

This just adds a note that the execution happens locally (not in
a Pod/container) and an extra call-out to the extension docs.