### PR TITLE
docs: add subnav with top reference pages

### DIFF
--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -1,100 +1,105 @@
-- title: Getting Started
-  items:
-  - title: Install
-    href: install.html
-  - title: Upgrade
-    href: upgrade.html
-  - title: "Tutorial: The First 15 Minutes"
-    href: tutorial.html
-  - title: "Tilt's Control Loop"
-    href: controlloop.html
-
-- title: Example Projects
-  include: examples
-
-- title: Onboarding Your Team
-  items:
-  - title: Choosing a Local Dev Cluster
-    href: choosing_clusters.html
-  - title: Local vs Remote Services
-    href: local_vs_remote.html
-  - title: "Before you ask your team to tilt up..."
-    href: onboarding_checklist.html
-  - title: "Guide for Application Developers"
-    href: welcome_to_tilt.html
-  - title: Accessing your resource with endpoints
-    href: accessing_resource_endpoints.html
-
-- title: Enhancements
-  items:
-  - title: Faster Development with Live Update (Tutorial)
-    href: live_update_tutorial.html
-  - title: Live Update Reference
-    href: live_update_reference.html
-  - title: "Debugging File Changes: Rebuilds and Ignores"
-    href: file_changes.html
-  - title: Play and Pause Resources with Manual Update Control
-    href: manual_update_control.html
-  - title: Resource Dependencies
-    href: resource_dependencies.html
-  - title: Local or Occasional Workflows with Local Resource
-    href: local_resource.html
-  - title: Tiltfile Configs
-    href: tiltfile_config.html
-  # todo: this will go under its own Debuggers section when we have enough articles to merit it
-  - title: Python Debuggers
-    href: debuggers_python.html
-  - title: Extensions
-    href: extensions.html
-  - title: Contribute an Extension
-    href: contribute_extension.html
-
-- title: Tilt Cloud
-  items:
+sidebar:
+  - title: Getting Started
+    items:
+    - title: Install
+      href: install.html
+    - title: Upgrade
+      href: upgrade.html
+    - title: "Tutorial: The First 15 Minutes"
+      href: tutorial.html
+    - title: "Tilt's Control Loop"
+      href: controlloop.html
+  - title: Example Projects
+    include: examples
+  - title: Onboarding Your Team
+    items:
+    - title: Choosing a Local Dev Cluster
+      href: choosing_clusters.html
+    - title: Local vs Remote Services
+      href: local_vs_remote.html
+    - title: "Before you ask your team to tilt up..."
+      href: onboarding_checklist.html
+    - title: "Guide for Application Developers"
+      href: welcome_to_tilt.html
+    - title: Accessing your resource with endpoints
+      href: accessing_resource_endpoints.html
+  - title: Enhancements
+    items:
+    - title: Faster Development with Live Update (Tutorial)
+      href: live_update_tutorial.html
+    - title: Live Update Reference
+      href: live_update_reference.html
+    - title: "Debugging File Changes: Rebuilds and Ignores"
+      href: file_changes.html
+    - title: Play and Pause Resources with Manual Update Control
+      href: manual_update_control.html
+    - title: Resource Dependencies
+      href: resource_dependencies.html
+    - title: Local or Occasional Workflows with Local Resource
+      href: local_resource.html
+    - title: Tiltfile Configs
+      href: tiltfile_config.html
+    # todo: this will go under its own Debuggers section when we have enough articles to merit it
+    - title: Python Debuggers
+      href: debuggers_python.html
+    - title: Extensions
+      href: extensions.html
+    - title: Contribute an Extension
+      href: contribute_extension.html
   - title: Tilt Cloud
-    href: tilt_cloud.html
-  - title: Teams
-    href: teams.html
-  - title: Snapshots
-    href: snapshots.html
-
-- title: Tilt Cookbooks
-  items:
-  - title: Tiltfile Concepts
-    href: tiltfile_concepts.html
-  - title: With CI
-    href: ci.html
-  - title: With Skaffold
-    href: skaffold.html
-  - title: With Helm
-    href: helm.html
-  - title: With Docker Compose
-    href: docker_compose.html
-  - title: "How to: Custom Resource Definitions"
-    href: custom_resource.html
-  - title: "How to: Building on a Base Image"
-    href: dependent_images.html
-  - title: "How to: Using a Personal Registry"
-    href: personal_registry.html
-  - title: "How to: Custom Build Scripts"
-    href: custom_build.html
-  - title: "How to: Bazel Build Scripts"
-    href: integrating_bazel_with_tilt.html
-  - title: "How to: Structuring Multiple Repos"
-    href: multiple_repos.html
-- title: Help
-  items:
-  - title: Who is Tilt for?
-    href: product_faq.html
-  - title: What does Tilt send?
-    href: telemetry_faq.html
-  - title: Why is Tilt broken?
-    href: debug_faq.html
-  - title: Frequently Asked Questions
-    href: faq.html
-  - title: Tiltfile API Reference
+    items:
+    - title: Tilt Cloud
+      href: tilt_cloud.html
+    - title: Teams
+      href: teams.html
+    - title: Snapshots
+      href: snapshots.html
+  - title: Tilt Cookbooks
+    items:
+    - title: Tiltfile Concepts
+      href: tiltfile_concepts.html
+    - title: With CI
+      href: ci.html
+    - title: With Skaffold
+      href: skaffold.html
+    - title: With Helm
+      href: helm.html
+    - title: With Docker Compose
+      href: docker_compose.html
+    - title: "How to: Custom Resource Definitions"
+      href: custom_resource.html
+    - title: "How to: Building on a Base Image"
+      href: dependent_images.html
+    - title: "How to: Using a Personal Registry"
+      href: personal_registry.html
+    - title: "How to: Custom Build Scripts"
+      href: custom_build.html
+    - title: "How to: Bazel Build Scripts"
+      href: integrating_bazel_with_tilt.html
+    - title: "How to: Structuring Multiple Repos"
+      href: multiple_repos.html
+  - title: Help
+    items:
+    - title: Who is Tilt for?
+      href: product_faq.html
+    - title: What does Tilt send?
+      href: telemetry_faq.html
+    - title: Why is Tilt broken?
+      href: debug_faq.html
+    - title: Frequently Asked Questions
+      href: faq.html
+    - title: Tiltfile API Reference
+      href: api.html
+    - title: Tilt CLI Reference
+      href: cli/tilt.html
+    - title: Code of Conduct
+      href: code_of_conduct.html
+subnav:
+  - title: Overview
+    href: ''
+  - title: Tiltfile API
     href: api.html
-  - title: Tilt CLI Reference
+  - title: CLI Reference
     href: cli/tilt.html
-  - title: Code of Conduct
-    href: code_of_conduct.html
+  - title: FAQ
+    href: faq.html

--- a/src/_layouts/docs.html
+++ b/src/_layouts/docs.html
@@ -3,10 +3,10 @@ layout: default
 ---
 {% assign page_href = page.url | slice: 1, page.url.size %}
 <div class="wrapper wrapper--docs u-marginBottom1_5">
-  <nav class="subnav">
+  <nav class="subnav" aria-label="Most Popular">
     <form action="/search" method="GET">
       <div class="formItem">
-        <input type="text" name="q" id="q" placeholder="Search" />
+        <input type="text" name="q" id="q" placeholder="Search" aria-label="Search Documentation" />
       </div>
     </form>
     <ul class="subnav-links">
@@ -16,7 +16,7 @@ layout: default
     </ul>
   </nav>
 
-  <nav class="sidebar">
+  <nav class="sidebar" aria-label="Primary">
     <button class="sidebar-opener u-showOnlyOnDocsMobile"
          onclick="document.querySelector('.sidebar').classList.toggle('is-open')">
       Contents

--- a/src/_layouts/docs.html
+++ b/src/_layouts/docs.html
@@ -1,16 +1,22 @@
 ---
 layout: default
 ---
+{% assign page_href = page.url | slice: 1, page.url.size %}
 <div class="wrapper wrapper--docs u-marginBottom1_5">
-  <nav class="sidebar">
-    <h2><a href="/">Docs</a></h2>
-
+  <nav class="subnav">
     <form action="/search" method="GET">
       <div class="formItem">
         <input type="text" name="q" id="q" placeholder="Search" />
       </div>
     </form>
+    <ul class="subnav-links">
+      {% for link in site.data.docs.subnav %}
+      <li><a class="sidebar-link {% if page_href == link.href %}sidebar-link-active{% endif %}" href="/{{link.href | escape}}">{{link.title | escape}}</a>
+      {% endfor %}
+    </ul>
+  </nav>
 
+  <nav class="sidebar">
     <button class="sidebar-opener u-showOnlyOnDocsMobile"
          onclick="document.querySelector('.sidebar').classList.toggle('is-open')">
       Contents
@@ -20,7 +26,7 @@ layout: default
 
     <div class="sidebar-contents">
 
-    {% for section in site.data.docs %}
+    {% for section in site.data.docs.sidebar %}
       {% if section.title %}
       <h3 class="sidebar-sectionTitle">{{ section.title | escape }}</h3>
       {% endif %}
@@ -28,13 +34,13 @@ layout: default
       {% if section.include == 'examples' %}
         <ul class="sidebar-sectionList">
           {% for page in site.data.examples %}
-            <li><a class="sidebar-link" href="/{{page.href | escape}}">{{page.title | escape}}</a>
+            <li><a class="sidebar-link {% if page_href == page.href %}sidebar-link-active{% endif %}" href="/{{page.href | escape}}">{{page.title | escape}}</a>
           {% endfor %}
         </ul>
       {% else %}
         <ul class="sidebar-sectionList">
           {% for page in section.items %}
-            <li><a class="sidebar-link" href="/{{page.href | escape}}">{{page.title | escape}}</a>
+            <li><a class="sidebar-link {% if page_href == page.href %}sidebar-link-active{% endif %}" href="/{{page.href | escape}}">{{page.title | escape}}</a>
           {% endfor %}
         </ul>
       {% endif %}

--- a/src/_sass/base.scss
+++ b/src/_sass/base.scss
@@ -207,8 +207,9 @@ pre {
   }
 }
 .wrapper--docs {
-  max-width: $header-width;
+  max-width: $header-width + $spacing-unit;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
 
   @include docs-mobile {

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -13,3 +13,10 @@
   width: 100%;
   height: 100%;
 }
+
+.body--docs {
+  .page-content {
+    // default layout includes excessive top padding
+    padding-top: 0;
+  }
+}

--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -111,8 +111,7 @@ li {
 
 .sidebar {
   display: block;
-  max-width: $sidebar-width;
-  width: 100%;
+  flex: 0 0 $sidebar-width;
   margin-right: $spacing-unit;
 
   @include docs-mobile {
@@ -121,8 +120,10 @@ li {
 }
 .docsContent {
   display: block;
-  max-width: $docs-width;
-  width: 100%;
+  flex: 1 0 $docs-width;
+  // needed to prevent child <pre> elements from expanding forever
+  // and causing wrapping problems
+  min-width: 0;
 
   @include docs-mobile {
     max-width: 100%;
@@ -607,6 +608,36 @@ h3.relatedHeader {
 .sidebar-link:hover {
   background-color: transparent;
   color: $color-grey;
+}
+
+.sidebar-link-active {
+  font-weight: bold;
+}
+
+.subnav {
+  flex-basis: 100%;
+  display: flex;
+  flex-direction: row-reverse;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+
+  form {
+    flex: 1 0 auto;
+  }
+
+  ul.subnav-links {
+    margin: 0;
+    flex: 4 0 auto;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    li {
+      display: inline;
+      margin-right: 1rem;
+    }
+  }
 }
 
 label, .formItem-label {


### PR DESCRIPTION
We've got a LOT of docs, but most of the time when folks end up
on the docs site, they probably want the API or CLI reference,
which are waaaay at the bottom.

This adds a subnav that includes a few links to the (hopefully)
most important pages. The search comes along for a ride out of
the sidebar as well.

There were some...interesting things going on with the layout,
so there's some general changes here to flexbox more flexbox-y,
but they should not actually change things, just make it more
friendly for future adaptions (like this one).

I did a sanity pass across all the pages on the docs site as well
as a few blog posts and whatever I could find on the "main" site.

![2021-07-08 18 02 56](https://user-images.githubusercontent.com/841263/124996375-d4dba980-e016-11eb-89c3-555599c13b7b.gif)

Thanks to @lucieleblanc for proposing this! 🙌 