### PR TITLE
docs: add office hours to docs and liftoff page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,9 +60,11 @@ For specific package managers (Homebrew, Scoop, Conda, asdf), see the [Installat
  find us in the [#tilt](https://kubernetes.slack.com/messages/CESBL84MV/)
  channel. Or [file an issue](https://github.com/tilt-dev/tilt/issues). For code snippets of Tiltfile functionality shared by the Tilt community, check out [Tilt Extensions](https://github.com/tilt-dev/tilt-extensions). 
  
-**Roadmap:** Help us figure out what to prioritize. Sign up for [Tilt office
-hours](https://calendly.com/han-yu/user-research). We'll discuss your experience
-with Tilt and ask for reactions on visuals or prototypes we're working on.
+**Roadmap:** Help us figure out what to prioritize. We hold Tilt Office Hours to pair
+on Tiltfiles and collect ideas for the roadmap. Next event at 12pm ET July 23rd. Copy it to [your
+calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=NXM1bzM0c2hlZmpzNWIwbjdlMHExMnVpODJfMjAyMTA3MjNUMTYwMDAwWiBjX2c0NDZoOHExNWtjbWhjOGVrMTUyZTBhZDA0QGc&tmsrc=c_g446h8q15kcmhc8ek152e0ad04%40group.calendar.google.com)
+or join via
+[Zoom](https://us02web.zoom.us/j/89661530301?pwd=WXFuTlg4aHRpckFNOFBtVHJMd2ZQZz09).
 
 **Contribute:** Check out our [guidelines](https://github.com/tilt-dev/tilt/blob/master/CONTRIBUTING.md) to contribute to Tilt's source code. To extend the capabilities of Tilt via new Tiltfile functionality, read more about [Extensions](extensions.html).
 

--- a/src/_data/github.yml
+++ b/src/_data/github.yml
@@ -1,2 +1,2 @@
-stars: 4.4k
+stars: 4.5k
 href: https://github.com/tilt-dev/tilt

--- a/src/_includes/index_cta.html
+++ b/src/_includes/index_cta.html
@@ -22,6 +22,15 @@
           <li>Pairing sessions to help you draft and evolve your Tiltfile.</li>
           <li>Help from our content strategists on how to talk about and teach Tilt.</li>
         </ul>
+        <hr/>
+        <p>
+          Not sure if a formal program is right for you?
+        </p>
+        <p>
+         We also hold Tilt Office
+Hours to pair on Tiltfiles. Next event at <b>12pm ET July 23rd</b>. Copy it to <a href="https://calendar.google.com/event?action=TEMPLATE&tmeid=NXM1bzM0c2hlZmpzNWIwbjdlMHExMnVpODJfMjAyMTA3MjNUMTYwMDAwWiBjX2c0NDZoOHExNWtjbWhjOGVrMTUyZTBhZDA0QGc&tmsrc=c_g446h8q15kcmhc8ek152e0ad04%40group.calendar.google.com">your
+            calendar</a> or join via <a href="https://us02web.zoom.us/j/89661530301?pwd=WXFuTlg4aHRpckFNOFBtVHJMd2ZQZz09">Zoom</a>.
+         </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/office-hours:

f50f0f1358d06b5097aaa7073088820db8df35df (2021-07-09 18:29:39 -0400)
docs: add office hours to docs and liftoff page

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics