### PR TITLE
site: open all external links with target="_blank"

### DIFF
--- a/blog/_posts/2019-02-18-how-i-built-a-simple-static-jekyll-site-without-installing-ruby-a-rant.md
+++ b/blog/_posts/2019-02-18-how-i-built-a-simple-static-jekyll-site-without-installing-ruby-a-rant.md
@@ -29,7 +29,7 @@ I want to try [Jekyll](https://jekyllrb.com/). It looks cool.
 I read the [install instructions](https://jekyllrb.com/docs/).
 
 The first step says:
-> Install a full [Ruby development environment](http://Ruby development environment)
+> Install a full Ruby development environment
 
 No
 

--- a/deploy/blog.dockerfile
+++ b/deploy/blog.dockerfile
@@ -6,4 +6,4 @@ RUN mkdir -p /blog
 ADD src /src/
 ADD blog /blog/
 ADD healthcheck.sh .
-ENTRYPOINT bundle exec jekyll serve --future --config _config.yml,_config-dev.yml
+ENTRYPOINT bundle exec jekyll serve --trace --future --config _config.yml,_config-dev.yml

--- a/deploy/docs.dockerfile
+++ b/deploy/docs.dockerfile
@@ -6,4 +6,4 @@ RUN mkdir -p /docs
 ADD src /src/
 ADD docs /docs/
 ADD healthcheck.sh .
-ENTRYPOINT bundle exec jekyll serve --config _config.yml,_config-dev.yml
+ENTRYPOINT bundle exec jekyll serve --trace --config _config.yml,_config-dev.yml

--- a/deploy/site.dockerfile
+++ b/deploy/site.dockerfile
@@ -1,4 +1,4 @@
 FROM tilt-site-base
 ADD ./src .
 ADD healthcheck.sh .
-ENTRYPOINT bundle exec jekyll serve --config _config.yml,_config-dev.yml
+ENTRYPOINT bundle exec jekyll serve --trace --config _config.yml,_config-dev.yml

--- a/docs/skaffold.md
+++ b/docs/skaffold.md
@@ -8,7 +8,7 @@ Tilt is a great upgrade to [Skaffold](https://skaffold.dev) for local dev. This 
 
 ## Comparison
 * Tilt's UI shows you status at a glance, so errors can't scroll off-screen. You can navigate the UI in your terminal and dig into the logs for just one service. (Tilt also has a global log if you do want the full firehose).
-* Tilt's configuration is [Starlark](https://github.com/bazelbuild/starlark#tour>), a subset of Python. This allows simple configs to be shorter and complex configs to be possible.
+* Tilt's configuration is [Starlark](https://github.com/bazelbuild/starlark#tour), a subset of Python. This allows simple configs to be shorter and complex configs to be possible.
 
 ## Translate Skaffold Configuration
 Skaffold concepts map almost directly into Tilt. Let's translate an example Skaffold configuration with two deployments and two images:

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -23,6 +23,7 @@ group :jekyll_plugins do
   gem "jekyll-paginate"
   gem "jekyll-sitemap"
   gem "jekyll-seo-tag"
+  gem "jekyll-target-blank"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -4,12 +4,12 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
-    ffi (1.15.0)
+    ffi (1.15.3)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.10)
@@ -46,6 +46,9 @@ GEM
     jekyll-tagging-related_posts (1.1.0)
       jekyll (>= 3.5, < 5.0)
       jekyll-tagging (~> 1.0)
+    jekyll-target-blank (2.0.0)
+      jekyll (>= 3.0, < 5.0)
+      nokogiri (~> 1.10)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -53,7 +56,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.5.1)
+    listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
@@ -61,14 +64,14 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    nokogiri (1.11.4-x86_64-linux)
+    nokogiri (1.12.3-x86_64-linux)
       racc (~> 1.4)
     nuggets (1.6.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
     racc (1.5.2)
-    rb-fsevent (0.10.4)
+    rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
@@ -93,10 +96,11 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   jekyll-tagging-related_posts
+  jekyll-target-blank
   kramdown (>= 2.3.1)
   minima (~> 2.0)
   rouge
   tzinfo-data
 
 BUNDLED WITH
-   2.2.16
+   2.2.24


### PR DESCRIPTION
Using https://github.com/keithmifsud/jekyll-target-blank which
automatically adds this for all external links.

Also fixed a couple broken links it flagged and added `--trace`
to the Docker entrypoints to make issues easier to track down
when Jekyll goes :boom:.