### PR TITLE
docs: make sidebar nav sticky w/ accordion sections

### DIFF
--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -1,5 +1,6 @@
 sidebar:
   - title: Getting Started
+    default: true
     items:
     - title: Install
       href: install.html

--- a/src/_layouts/docs.html
+++ b/src/_layouts/docs.html
@@ -27,24 +27,34 @@ layout: default
     <div class="sidebar-contents">
 
     {% for section in site.data.docs.sidebar %}
-      {% if section.title %}
-      <h3 class="sidebar-sectionTitle">{{ section.title | escape }}</h3>
-      {% endif %}
-
+      {% assign active_section = false %}
       {% if section.include == 'examples' %}
-        <ul class="sidebar-sectionList">
-          {% for page in site.data.examples %}
-            <li><a class="sidebar-link {% if page_href == page.href %}sidebar-link-active{% endif %}" href="/{{page.href | escape}}">{{page.title | escape}}</a>
-          {% endfor %}
-        </ul>
+        {% assign active_section = site.data.examples | find: "href", page_href %}
+      {% elsif section.default and page_href == '' %}
+        {% assign active_section = true %}
       {% else %}
-        <ul class="sidebar-sectionList">
-          {% for page in section.items %}
-            <li><a class="sidebar-link {% if page_href == page.href %}sidebar-link-active{% endif %}" href="/{{page.href | escape}}">{{page.title | escape}}</a>
-          {% endfor %}
-        </ul>
+        {% assign active_section = section.items | find: "href", page_href %}
       {% endif %}
 
+      <div class="sidebar-section">
+        <input id="section{{ forloop.index }}" type="checkbox" {% if active_section %}checked{% endif %} />
+        <label class="sidebar-sectionTitle" for="section{{ forloop.index }}">{{ section.title | escape }}</label>
+<!--        <h3 class="sidebar-sectionTitle">{{ section.title | escape }}</h3>-->
+
+        {% if section.include == 'examples' %}
+          <ul class="sidebar-sectionList">
+            {% for page in site.data.examples %}
+              <li><a class="sidebar-link {% if page_href == page.href %}{% assign active_section = true %}sidebar-link-active{% endif %}" href="/{{page.href | escape}}">{{page.title | escape}}</a>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <ul class="sidebar-sectionList">
+            {% for page in section.items %}
+              <li><a class="sidebar-link {% if page_href == page.href %}sidebar-link-active{% endif %}" href="/{{page.href | escape}}">{{page.title | escape}}</a>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
     {% endfor %}
 
     </div>  

--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -114,10 +114,43 @@ li {
   flex: 0 0 $sidebar-width;
   margin-right: $spacing-unit;
 
+  position: sticky;
+  top: 0;
+  overflow-y: auto;
+  max-height: 100vh;
+
   @include docs-mobile {
     max-width: $col-2of3-width;
   }
 }
+
+.sidebar-section {
+  input {
+    display: none;
+  }
+
+  label {
+    display: block;
+    cursor: pointer;
+  }
+
+  ul {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 75ms ease-in-out;
+  }
+
+  input:checked + label {
+    font-weight: bold;
+  }
+
+  input:checked + label + ul {
+    //display: block;
+    max-height: 100vh;
+    transition: max-height 250ms ease-in-out;
+  }
+}
+
 .docsContent {
   display: block;
   flex: 1 0 $docs-width;
@@ -582,8 +615,8 @@ h3.relatedHeader {
 
 .sidebar-sectionList {
   list-style-type: none;
-  margin-bottom: $spacing-unit / 2;
-  margin-left: 1.5em;  /* balanced out by text-indent -1.5em below */
+  margin: 0 0 $spacing-unit / 2 0;
+  padding-left: 1.5em;  /* balanced out by text-indent -1.5em below */
 
   font-family: $chrome-font-family;
   font-weight: $chrome-font-weight;


### PR DESCRIPTION
* "Getting Started" is considered the default section and
  auto-expanded on landing page
* Otherwise, current page's section is pre-expanded, others
  are collapsed by default
* Sticky and vertically scrolls if still overflows
* CSS-only, no Javascript
  * It MIGHT make sense to throw in some progressive enhancement JS to `scrollTo()` when expanding a section 🤔 

![2021-08-12 16 24 37](https://user-images.githubusercontent.com/841263/129266248-27417f98-5a4c-4bd3-a8a2-980aab3df099.gif)
