### PR TITLE
docs: sticky sidebar nav

### DIFF
--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -114,6 +114,12 @@ li {
   flex: 0 0 $sidebar-width;
   margin-right: $spacing-unit;
 
+  // sticky on scroll
+  position: sticky;
+  top: 0;
+  overflow-y: auto;
+  max-height: 100vh;
+
   @include docs-mobile {
     max-width: $col-2of3-width;
   }
@@ -582,8 +588,8 @@ h3.relatedHeader {
 
 .sidebar-sectionList {
   list-style-type: none;
-  margin-bottom: $spacing-unit / 2;
-  margin-left: 1.5em;  /* balanced out by text-indent -1.5em below */
+  margin: 0 0 $spacing-unit / 2 0;
+  padding-left: 1.5em;  /* balanced out by text-indent -1.5em below */
 
   font-family: $chrome-font-family;
   font-weight: $chrome-font-weight;


### PR DESCRIPTION
On scroll, the sidebar nav will stay sticky at the top of the
screen.

You can still scroll to the bottom of the content area (i.e. the
footer links) and it _will_ scroll out at that point. This behavior
is pretty consistent with other sticky navs on a few docs sites I
played with.

![sticky nav demo](https://user-images.githubusercontent.com/841263/129619493-0b84249d-7bc9-4844-96be-01834317c5a4.gif)
