### PR TITLE
docs: make entire header a permalink

### DIFF
--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -413,7 +413,8 @@ h2, .docsContent h1 {
 h3,
 .wrapper--landing h2,
 .docsContent h2,
-.blogContent h2 {
+.blogContent h2,
+.docsContent h2 a {
   font-family: $header-font-family;
   font-variant-ligatures: none;
   font-size: 24px;
@@ -427,6 +428,13 @@ h3,
     font-size: 22px;
     line-height: 28px;
   }
+}
+
+.docsContent h2 a:hover:before {
+  content: "🔗 ";
+  position: absolute;
+  margin-left: -1.25em;
+  font-size: 75%;
 }
 
 h4,

--- a/src/assets/js/links.js
+++ b/src/assets/js/links.js
@@ -2,18 +2,16 @@
 // http://blog.parkermoore.de/2014/08/01/header-anchor-links-in-vanilla-javascript-for-github-pages-and-jekyll/
 
 (function() {
-  var anchorForId = function (id) {
-    var anchor = document.createElement("a");
-    anchor.className = "permalink";
-    anchor.href      = "#" + id;
-    anchor.innerHTML = "►";
-    return anchor;
-  };
-
   document.onreadystatechange = function () {
     if (this.readyState === "complete") {
-      let links = Array.from(document.querySelectorAll('.docsContent h2[id],.docsContent h3[id]'))
-      links.forEach((el) => el.insertBefore(anchorForId(el.id), el.firstChild))
+      const links = Array.from(document.querySelectorAll('.docsContent h2[id],.docsContent h3[id]'));
+      links.forEach(el => {
+        // wrap the header contents in a link so that the entire thing is clickable
+        const link = document.createElement('a');
+        link.href = '#' + el.id;
+        link.innerHTML = el.innerHTML;
+        el.innerHTML = link.outerHTML;
+      })
     }
   };
 })()


### PR DESCRIPTION
This behavior mimics how GitHub (and many other sites) behave,
which is a pretty familiar pattern for users.

The entire header is a permalink now, and the '🔗' shows up on
hover (replacing `►`).

(As a sidenote, the permalink functionality does not really need
Javascript - we should arguably rewrite this as a Jekyll include
to set up the permalinks at generation time, but at the same time,
functionality without it isn't hugely degraded, so it's not worth
it right now.)

![header permalinks demo](https://user-images.githubusercontent.com/841263/129630663-f33fa6e2-d9a5-42b1-9667-75c94e0d7337.gif)
