### PR TITLE
docs: search styling improvements

### DIFF
--- a/docs/search.html
+++ b/docs/search.html
@@ -2,9 +2,23 @@
 title: Search
 description: "Search the Tilt documentation."
 layout: docs
+hideHelpfulForm: true
 ---
 
 <script>
+(function() {
+  const searchEl = document.getElementById('q');
+  if (!searchEl) {
+    return;
+  }
+  try {
+    const urlParams = new URLSearchParams(window.location.search);
+    searchEl.value = urlParams.get('q');
+  } catch {
+    // just ignore, search box won't be pre-populated but it's ok
+  }
+})();
+
  (function() {
      var cx = '017353557192452135467:flbjzvynczi';
      var gcse = document.createElement('script');
@@ -16,3 +30,6 @@ layout: docs
  })();
 </script>
 <gcse:searchresults-only></gcse:searchresults-only>
+<noscript>
+Javscript is required for search functionality.
+</noscript>

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -22,4 +22,11 @@
   <!-- tilt.dev typekit project -->
   <link rel="stylesheet" href="https://use.typekit.net/yii5fqs.css">
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet">
+  <noscript>
+  <style>
+  .js-only {
+      display:none;
+  }
+  </style>
+  </noscript>
 </head>

--- a/src/_includes/helpful_form.html
+++ b/src/_includes/helpful_form.html
@@ -11,7 +11,7 @@ let helpfulFormSend = function(el, action) {
 }
 </script>
 
-<div class="helpfulForm brandBox u-marginTop2" style="max-width: 400px">
+<div class="helpfulForm brandBox u-marginTop2 js-only" style="max-width: 400px">
   {% include brandBoxBg.html %}
   <h3>Was this doc helpful?</h3>
 

--- a/src/_layouts/docs.html
+++ b/src/_layouts/docs.html
@@ -4,7 +4,7 @@ layout: default
 {% assign page_href = page.url | slice: 1, page.url.size %}
 <div class="wrapper wrapper--docs u-marginBottom1_5">
   <nav class="subnav" aria-label="Most Popular">
-    <form action="/search" method="GET">
+    <form class="js-only" action="/search" method="GET">
       <div class="formItem">
         <input type="text" name="q" id="q" placeholder="Search" aria-label="Search Documentation" />
       </div>
@@ -59,7 +59,9 @@ layout: default
     {{ content }}
 
     <div class="docsFooter">
-    {% include helpful_form.html %}
+    {% if page.hideHelpfulForm != true %}
+        {% include helpful_form.html %}
+    {% endif %}
     <a id="scrollToTop" href="#">
       <span role="presentation">↑</span>
       Back to top

--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -679,6 +679,7 @@ button.nav-accordion__header {
   flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
+  margin-bottom: 1.25 * $spacing-unit;
 
   form {
     flex: 1 0 auto;
@@ -1417,7 +1418,6 @@ img.no-shadow {
 .formItem {
   display: block;
   position: relative;
-  padding-bottom: 1.25 * $spacing-unit;
 
   @include mobile {
     padding-bottom: $spacing-unit;


### PR DESCRIPTION
* Populate search box with `q` query param
* Hide "Was this doc helpful?" on search results
* Hide search element if JS disabled
* Show notice that JS is required on search page if disabled
* (Bonus) Hide "Was this doc helpful?" on all pages if JS disabled

<img width="1170" alt="docs search page after changes" src="https://user-images.githubusercontent.com/841263/130272669-a4ba0c4f-ff6b-4a69-894a-5efba78bae37.png">
(I cheated and deleted some results to make this screenshot not 10,000px tall)