### PR TITLE
docs: re-enable links opening in external window

### DIFF
--- a/docs/search.html
+++ b/docs/search.html
@@ -15,4 +15,4 @@ layout: docs
      s.parentNode.insertBefore(gcse, s);
  })();
 </script>
-<gcse:searchresults-only></gcse:searchresults-only>
+<div class="gcse-searchresults-only" />

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -23,6 +23,7 @@ group :jekyll_plugins do
   gem "jekyll-paginate"
   gem "jekyll-sitemap"
   gem "jekyll-seo-tag"
+  gem "jekyll-target-blank"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
     jekyll-tagging-related_posts (1.1.0)
       jekyll (>= 3.5, < 5.0)
       jekyll-tagging (~> 1.0)
+    jekyll-target-blank (2.0.0)
+      jekyll (>= 3.0, < 5.0)
+      nokogiri (~> 1.10)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -93,6 +96,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   jekyll-tagging-related_posts
+  jekyll-target-blank
   kramdown (>= 2.3.1)
   minima (~> 2.0)
   rouge


### PR DESCRIPTION
Re-add the `jekyll-target-blank` plugin but adjust the Google Custom
Search so that it doesn't break it.

The search fix is to use a `<div>` instead of the custom
`<gcse:searchresults-only>` element (which was erroneously having its
`gcse` "namespace" chopped off by nokogiri during DOM processing). This
is actually the way that Google has it in their docs now as of Aug 2021
and works fine.

While it's not great that nokogiri can't handle this properly, the
likelihood we use custom elements in the future with prefixed namespaces
is minimal, and the alternatives are:
 * Use JS to add `target="_blank"` to all links on page load
 * Remember to specify it manually on all external links