### PR TITLE
docs: eliminate weird search result hover

### DIFF
--- a/src/_sass/search.scss
+++ b/src/_sass/search.scss
@@ -38,6 +38,12 @@
   }
 }
 
+a.gs-title {
+  // something about how the GCSE CSS/JS interacts causes weird hover transitions when the title includes
+  // a matching term from the search (which is bolded)
+  transition: none;
+}
+
 a.gs-title:hover {
   background-color: $color-blue;
 }


### PR DESCRIPTION
When there's a matching term from the search in the link title,
it's in a `<b>` inside the `<a>`. (Note: due to our styles, you
can't actually tell it's bold because the whole title always is.)

For whatever reason, that's causing it to animate at a different
rate than the rest of the title, which is weird. Similar links in
other places on the docs site don't behave like this, and there's
no apparent `transition` rule conflicting. It's likely some weird
mix of dynamic CSS/JS for the results.

Regardless, I have no good explanation for this and it's not worth
debugging, so the "fix" here is to just remove hover animation on
the search result titles entirely.

Per suggestion from #916.