### PR TITLE
api: add docs for suppress_unused_image_warnings

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -442,7 +442,7 @@ def k8s_resource(workload: str = "", new_name: str = "",
     links: one or more links to be associated with this resource in the UI. For more info, see
       `Accessing Resource Endpoints <accessing_resource_endpoints.html#arbitrary-links>`_.
     labels: used to group resources in the Web UI, (e.g. you want all frontend services displayed together, while test and backend services are displayed seperately). A label must start and end with an alphanumeric character, can include ``_``, ``-``, and ``.``, and must be 63 characters or less. For an example, see `Resource Grouping <tiltfile_concepts.html#resource-groups>`_.
-    discovery_strategy: Possible values: '', 'default', 'selectors-only'. When '' or 'default', Tilt both uses `extra_pod_selectors` and traces k8s owner references to identify this resource's pods. When 'selectors-only', Tilt uses only `extra_pod_selectors`. 
+    discovery_strategy: Possible values: '', 'default', 'selectors-only'. When '' or 'default', Tilt both uses `extra_pod_selectors` and traces k8s owner references to identify this resource's pods. When 'selectors-only', Tilt uses only `extra_pod_selectors`.
   """
   pass
 
@@ -1088,7 +1088,10 @@ def secret_settings(disable_scrub: bool = False) -> None:
 """
 
 
-def update_settings(max_parallel_updates: int=3, k8s_upsert_timeout_secs: int=30) -> None:
+def update_settings(
+    max_parallel_updates: int=3,
+    k8s_upsert_timeout_secs: int=30,
+    suppress_unused_image_warnings: Union[str, List[str]]=None) -> None:
   """Configures Tilt's updates to your resources. (An update is any execution of or
   change to a resource. Examples of updates include: doing a docker build + deploy to
   Kubernetes; running a live update on an existing container; and executing
@@ -1099,6 +1102,8 @@ def update_settings(max_parallel_updates: int=3, k8s_upsert_timeout_secs: int=30
   Args:
     max_parallel_updates: maximum number of updates Tilt will execute in parallel. Default is 3. Must be a positive integer.
     k8s_upsert_timeout_secs: timeout (in seconds) for Kubernetes upserts (i.e. ``create``/``apply`` calls). Minimum value is 1.
+    suppress_unused_image_warnings: suppresses warnings about images that aren't deployed.
+      Accepts a list of image names, or '*' to suppress warnings for all images.
 """
 
 def watch_settings(ignore: Union[str, List[str]]) -> None:

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -8543,6 +8543,10 @@ sent or read from the socket.
            <em>
             k8s_upsert_timeout_secs=30
            </em>
+           ,
+           <em>
+            suppress_unused_image_warnings=None
+           </em>
            <span class="sig-paren">
             )
            </span>
@@ -8609,6 +8613,43 @@ a local resource command).
                   </span>
                  </code>
                  calls). Minimum value is 1.
+                </li>
+                <li>
+                 <strong>
+                  suppress_unused_image_warnings
+                 </strong>
+                 (
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Union
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ,
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   List
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ],
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   None
+                  </span>
+                 </code>
+                 ]) &#x2013; suppresses warnings about images that aren&#x2019;t deployed.
+Accepts a list of image names, or &#x2018;*&#x2019; to suppress warnings for all images.
                 </li>
                </ul>
               </td>


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/unused:

2c341e1deb03678e7efb0ce6c87664442d3d8895 (2021-09-03 16:30:58 -0400)
api: add docs for suppress_unused_image_warnings

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics