### PR TITLE
docs: add in-section nav for tutorial

### DIFF
--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -11,6 +11,7 @@ sidebar:
     - title: "Tilt's Control Loop"
       href: controlloop.html
   - title: Tutorial
+    inSectionNav: true
     items:
     - title: Overview
       href: tutorial/index.html

--- a/src/_layouts/docs.html
+++ b/src/_layouts/docs.html
@@ -38,6 +38,11 @@ layout: default
         {% assign active_section = pages | find: "href", page_href %}
       {% endif %}
 
+      {% if active_section %}
+        {% assign current_section = section %}
+        {% assign current_section_pages = pages %}
+      {% endif %}
+
       <h3 class="sidebar-sectionTitle js-accordion__header" {% if active_section %}data-accordion-opened="true"{% endif %}>
         {{ section.title | escape }}
       </h3>
@@ -49,7 +54,6 @@ layout: default
       </ul>
 
     {% endfor %}
-
     </div>  
 
   </nav>
@@ -62,6 +66,36 @@ layout: default
     </div>
     
     {{ content }}
+
+    {% if current_section.inSectionNav %}
+      <div class="section-nav" role="navigation" aria-label="Section navigation">
+        {% for page in current_section_pages %}
+          {% unless page_href == page.href %}
+            {% continue %}
+          {% endunless %}
+          {% unless forloop.first %}
+            {% assign prevIndex = forloop.index0 | minus: 1 %}
+            {% assign prevPage = current_section_pages[prevIndex] %}
+            <a href="/{{ prevPage.href | escape }}"
+               class="section-nav-prev"
+               aria-label="Previous Section: {{ prevPage.title | escape }}">
+              <span aria-hidden="true">←</span>
+              {{ prevPage.title | escape }}
+            </a>
+          {% endunless %}
+          {% unless forloop.last %}
+            {% assign nextIndex = forloop.index0 | plus: 1 %}
+            {% assign nextPage = current_section_pages[nextIndex] %}
+            <a href="/{{ nextPage.href | escape }}"
+               class="section-nav-next"
+               aria-label="Next Section: {{ nextPage.title | escape }}">
+              {{ nextPage.title | escape }}
+              <span aria-hidden="true">→</span>
+            </a>
+          {% endunless %}
+        {% endfor %}
+      </div>
+    {% endif %}
 
     <div class="docsFooter">
     {% if page.hideHelpfulForm != true %}

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -20,3 +20,18 @@
     padding-top: 0;
   }
 }
+
+.section-nav {
+  margin: 2rem 1rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  .section-nav-prev {
+    margin-right: auto;
+  }
+
+  .section-nav-next {
+    margin-left: auto;
+  }
+}


### PR DESCRIPTION
From the nav, sections can have "in-section" nav which adds
previous and next links (based on sidebar order).

For now, this will just be used for the tutorial.

<img width="812" alt="in-section nav example" src="https://user-images.githubusercontent.com/841263/135337972-5c778669-a4de-4e0e-93e7-c7f917227d27.png">


