### PR TITLE
docs: more specific help pointers

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -212,7 +212,7 @@ def docker_build(ref: str,
 
   Note that you can't set both the `dockerfile` and `dockerfile_contents` arguments (will throw an error).
 
-  Note also that the `entrypoint` parameter is not supported for Docker Compose resources. If you need it for your use case, let us know.
+  Note also that the `entrypoint` parameter is not supported for Docker Compose resources.
 
   Args:
     ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'). If this image will be used in a k8s resource(s), this ref must match the ``spec.container.image`` param for that resource(s).
@@ -805,8 +805,6 @@ def default_registry(host: str, host_from_cluster: str = None, single_name: str 
   2. Prepend the value of ``host`` and a ``/``.
 
   e.g., with ``default_registry('gcr.io/myorg')``, an image called ``user-service`` becomes ``gcr.io/myorg/user-service``.
-
-  (Note: this logic is currently crude, on the assumption that development image names are ephemeral and unimportant. `Please let us know <https://github.com/tilt-dev/tilt/issues>`_ if they don't suit you!)
   """
   pass
 
@@ -1100,8 +1098,6 @@ def secret_settings(disable_scrub: bool = False) -> None:
   'mysecurepassword', Tilt redacts this string if ever it appears in the logs,
   to prevent users from accidentally sharing sensitive information in snapshots etc.
 
-  If you need other configuration options, `let us know <https://github.com/tilt-dev/tilt/issues>`_.
-
   Args:
     disable_scrub: if True, Tilt will *not* scrub secrets from logs.
 """
@@ -1115,8 +1111,6 @@ def update_settings(
   change to a resource. Examples of updates include: doing a docker build + deploy to
   Kubernetes; running a live update on an existing container; and executing
   a local resource command).
-
-  If you need other configuration options, `let us know <https://github.com/tilt-dev/tilt/issues>`_.
 
   Args:
     max_parallel_updates: maximum number of updates Tilt will execute in parallel. Default is 3. Must be a positive integer.

--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -110,7 +110,4 @@ Hopefully that's enough to get you interested and started!
 
 More information can be found in the [uibutton docs][uibutton-docs].
 
-If you have any feedback, feature requests, or inventive uses of this that you'd
-like to share with us, please [reach out](https://tilt.dev/contact)!
-
 [uibutton-docs]: https://github.com/tilt-dev/tilt-extensions/blob/master/uibutton/README.md

--- a/docs/custom_build.md
+++ b/docs/custom_build.md
@@ -186,7 +186,7 @@ guide](custom_resource.html#advanced-pod-creation) instead.
 ## Live Update and Other Features
 Tilt's `docker_build` supports other options. The most impactful is [Live Update](live_update_tutorial.html), which lets you update code in Kubernetes without doing a full image build.  `custom_build` supports this as well, using the same syntax.
 
-`custom_build` supports most other options of `docker_build`, and a few specific to non-Docker container builders. If you find an option you think should exist but doesn't, let us know in the `#tilt` channel in [Kubernetes Slack](http://slack.k8s.io).
+`custom_build` supports most other options of `docker_build`, and a few specific to non-Docker container builders.
 
 ### Adjust File Watching with `ignore`
 While most of the points in our [Debugging File Changes](/file_changes.html) guide hold true for `custom_build`, the `ignore` parameter (which adjusts the set of files watched for a given build) works a bit differently, and is worth discussing briefly.

--- a/docs/debuggers_python.md
+++ b/docs/debuggers_python.md
@@ -61,5 +61,16 @@ When using `remote-pdb`, the log line that tells you that your debugger is activ
 
 (See [this interactive snapshot](https://cloud.tilt.dev/snapshot/Aer7necLsNHx2TGFkfc=) for a closer look.)
 
-## Future Work
-As we find more Python debuggers that fit well into Tilt-based workflows, we'll create guides/example projects for them. Have a favorite remote-connection-friendly Python debugger that you'd like to see us cover? [Let us know](https://tilt.dev/contact)!
+## Connecting Your Own Debugger
+
+Tilt itself does not have any code for connecting to a particular debugger. None
+of the examples in this guide use "magic" primitives.
+
+Instead, Tilt provides a standardized API for coordinating any debugger with your dev environment.
+
+Do you use a debugger that's not listed here?
+
+Use [`local_resource`](/local_resource.html) to spin it up. 
+
+Once you've got it running, consider packaging it up as [a Tilt
+extension](/extensions.md) for others to use.

--- a/docs/example_python.md
+++ b/docs/example_python.md
@@ -11,7 +11,7 @@ Kubernetes is a huge wrench in the works.
 
 Let's fix this.
 
-In this example, we're going to take you through a simple “hello world” server written in Python that uses [Flask](https://palletsprojects.com/p/flask/), a lightweight web application framework.  (Want this guide for Django or another framework? [Let us know](https://tilt.dev/contact).)
+In this example, we're going to take you through a simple “hello world” server written in Python that uses [Flask](https://palletsprojects.com/p/flask/), a lightweight web application framework.
 
 Consider watching this companion video if you prefer. Or come back to it afterward.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -26,7 +26,10 @@ Tilt resolves `ext://hello_world` to [tilt-extensions/blob/master/hello_world/Ti
 ## Commit to source control
 Commit the `tilt_modules` directory to your project repo (**do not** `gitignore` it), so that your teammates don't have to download it, and to ensure that your entire team uses the same copy of the extension. Once Tilt has downloaded an extension, it will not be updated, avoiding suprise breakages.
 
-Tilt doesn't support versioning of extensions at the moment. If you are interested in versioning, [let us know](https://github.com/tilt-dev/tilt/issues/3426).
+Tilt doesn't support versioning of extensions at the moment.
+
+(To get notified about versioning, please subscribe to [this issue](https://github.com/tilt-dev/tilt/issues/3426)
+and thumbs-up it so we know you care about it.)
 
 ## Avoid changing extensions
 Avoid changing extensions directly in `tilt_modules`. If you're interested in modifying an extension, consider [contributing a new one](contribute_extension.html) instead,

--- a/docs/live_update_reference.md
+++ b/docs/live_update_reference.md
@@ -49,7 +49,7 @@ When you tell Tilt how to build an image, you specify some set of files to watch
     <figcaption>An illegal 'sync': attempting to sync files that aren't included in the docker_build context</figcaption>
 </figure>
 
-The `sync` above is invalid, because it attempts to sync files that we're not even watching (seen here highlighted in blue). To put it another way: there's no way for those files to get into the container in the first place, because they would never be included in the Docker build. (If this is functionality you need, [let us know](https://tilt.dev/contact).)
+The `sync` above is invalid, because it attempts to sync files that we're not even watching (seen here highlighted in blue). To put it another way: there's no way for those files to get into the container in the first place, because they would never be included in the Docker build.
 
 <figure>
     <img src="/assets/img/liveupdate-sync-docker-context.png" class="no-shadow" alt="A valid use of 'sync' (all sync'd files are subsets of docker_build.context)">
@@ -89,7 +89,9 @@ This step is optional, though if provided, it must come at the beginning of the 
 ### [run(cmd: str, trigger=None: str || List[str])](api.html#api.run)
 The first argument to `run` is a the command to be executed _on the running container_. Currently, all commands are executed from `/`, so be sure to use absolute paths!
 
-Currently, all of your `run` steps must come after all of your `sync` steps. (If you need different behavior, let us know!) If you provide multiple `run` steps, the commands will be executed in the order given. 
+Currently, all of your `run` steps must come after all of your `sync` steps. 
+
+If you provide multiple `run` steps, the commands will be executed in the order given. 
 
 #### Run triggers
 
@@ -158,4 +160,4 @@ language, all our major example projects use Live Update:
 
 ---
 
-[^1]: The initial build is always a full build because Live Update needs a running container to modify. Thus, your base build (Docker/Custom Build) should be sufficient to create your dev image, and should not rely on any `sync`'d files or `run` commands. (If this is functionality you need, [let us know](https://tilt.dev/contact).)
+[^1]: The initial build is always a full build because Live Update needs a running container to modify. Thus, your base build (Docker/Custom Build) should be sufficient to create your dev image, and should not rely on any `sync`'d files or `run` commands.

--- a/docs/resource_assembly_migration.md
+++ b/docs/resource_assembly_migration.md
@@ -26,6 +26,3 @@ Migrating to the new behavior should mostly be a matter of:
 3. If your `k8s_resource` calls say unknown resource (because Tilt now names by k8s object instead of image),
    either change the first arg to `k8s_resource` to match the new name, or use [`workload_to_resource_function`](/api.html#api.workload_to_resource_function) to change the naming rules.
 4. Let any teammates know that they need to upgrade Tilt.
-
-Please don't hesitate to [reach out](faq.html#q-how-do-i-get-help-with-tilt)
-if you run into any problems or confusion!

--- a/docs/resource_dependencies.md
+++ b/docs/resource_dependencies.md
@@ -45,8 +45,4 @@ affects the first build after a `tilt up`. e.g., Once any version of `database`
 has been running at least once, its dependencies are unblocked to build for the
 rest of Tilt's lifetime.
 
-We think this feature is useful as-is, but are aware there are more possibilities
-for it. Please [reach out](https://tilt.dev/contact) if it's not meeting your
-needs!
-
 [readiness-probe]: local_resource.html#readiness_probe

--- a/docs/tests_in_tilt.md
+++ b/docs/tests_in_tilt.md
@@ -108,6 +108,3 @@ for tf in test_files:
           if f.startswith(slug)]
   test(slug, cmd, deps=deps)
 ```
-
-## What's next?
-There's a lot more we want to do with this feature, but above all, we want to know what our users want. Let us know what you think!

--- a/docs/tiltfile_concepts.md
+++ b/docs/tiltfile_concepts.md
@@ -35,7 +35,18 @@ k8s_yaml(kustomize('config_dir')) # built-in support for popular tools
 k8s_yaml(helm('chart_dir'))
 ```
 
-Tilt has built-in functions to generate Kubernetes YAML with `kustomize` or `helm`. (If you think we're overlooking a popular tool, let us know so we can add it.)
+Tilt has built-in Tiltfile functions to generate Kubernetes YAML with `kustomize` or `helm`.
+
+These functions are mostly wrappers around the `local()` built-in, which
+can execute arbitrary shell commands.
+
+Tilt's [extension system](/extensions.html) allows you to write new functions to
+invoke whatever tool you use to generate Kubernetes configs, and automatically
+deploy them as part of your dev environment. For a simple example, see the
+[`namespace`
+extension](https://github.com/tilt-dev/tilt-extensions/tree/master/namespace) or
+the [`secret`
+extension](https://github.com/tilt-dev/tilt-extensions/tree/master/secret).
 
 ## Custom Commands
 If your project uses a custom tool to generate Kubernetes YAML, you can still use Tilt. You don't have to wait for us to add support or fork Tilt and implement it yourself. Run a custom command with the `local` function:

--- a/docs/tiltfile_config.md
+++ b/docs/tiltfile_config.md
@@ -232,8 +232,8 @@ then you do _not_ specify the flag and all positional arguments will be merged i
 In both cases, `config.parse()['foo'] == ['bar', 'baz']`.
 
 ## Future Directions
-This section describes places we expect the config to go. Let us know if any of
-these would be particularly helpful to you and your team.
+This section describes places we expect the config to go.
+
 ### More Kinds of Settings
 You should be able to define more kinds of settings (for example, an enum). By moving error-checking to the built-in
 library, you can make your Tiltfile shorter and more correct.

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -1530,13 +1530,6 @@ tag instead.
             </code>
             .
            </p>
-           <p>
-            (Note: this logic is currently crude, on the assumption that development image names are ephemeral and unimportant.
-            <a class="reference external" href="https://github.com/tilt-dev/tilt/issues">
-             Please let us know
-            </a>
-            if they don&#x2019;t suit you!)
-           </p>
            <table class="docutils field-list" frame="void" rules="none">
             <col class="field-name">
             <col class="field-body">
@@ -1754,7 +1747,7 @@ ensures a pretty high bar of intent.
             <cite>
              entrypoint
             </cite>
-            parameter is not supported for Docker Compose resources. If you need it for your use case, let us know.
+            parameter is not supported for Docker Compose resources.
            </p>
            <table class="docutils field-list" frame="void" rules="none">
             <col class="field-name">
@@ -8106,13 +8099,6 @@ the text of any Secrets from the logs; e.g. if Tilt applies a Secret with conten
 &#x2018;mysecurepassword&#x2019;, Tilt redacts this string if ever it appears in the logs,
 to prevent users from accidentally sharing sensitive information in snapshots etc.
            </p>
-           <p>
-            If you need other configuration options,
-            <a class="reference external" href="https://github.com/tilt-dev/tilt/issues">
-             let us know
-            </a>
-            .
-           </p>
            <table class="docutils field-list" frame="void" rules="none">
             <col class="field-name">
             <col class="field-body">
@@ -8600,13 +8586,6 @@ sent or read from the socket.
 change to a resource. Examples of updates include: doing a docker build + deploy to
 Kubernetes; running a live update on an existing container; and executing
 a local resource command).
-           </p>
-           <p>
-            If you need other configuration options,
-            <a class="reference external" href="https://github.com/tilt-dev/tilt/issues">
-             let us know
-            </a>
-            .
            </p>
            <table class="docutils field-list" frame="void" rules="none">
             <col class="field-name">


### PR DESCRIPTION
Hello @ellenkorbes,

Please review the following commits I made in branch nicks/docs:

a161345ad7559c5c79874449543b32dbb83ca7e0 (2021-10-01 15:18:32 -0400)
docs: more specific help pointers
In technical documentation, I don't think it's helpful to be constantly saying
"please suggest changes to this API!"

Most readers are just trying to understand how to get their app working --
and will not be well-equipped to suggest changes and it's weird to ask them to.

The only exception is when we have specific pointers to issues
or documentation on how to script custom behavior.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics