### PR TITLE
docs: add honeycomb to api docs

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,9 +1,8 @@
 # -*- mode: Python -*-
 
-load('ext://tilt_inspector', 'tilt_inspector')
-
-tilt_inspector(port=4009)
-#enable_feature('live_update_v2')
+load('ext://honeycomb', 'honeycomb_collector')
+if os.environ.get('HONEYCOMB_API_KEY', '') and os.environ.get('HONEYCOMB_DATASET', ''):
+  honeycomb_collector()
 
 # Uncomment to try the kubefwd extension.
 #v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions')

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,7 @@ examples of what you can do with a Tiltfile. Load them into your own Tiltfile. I
 - [`git_resource`](https://github.com/tilt-dev/tilt-extensions/tree/master/git_resource): Deploy a dockerfile from a remote repository -- or specify the path to a local checkout for local development.
 - [`hello_world`](https://github.com/tilt-dev/tilt-extensions/tree/master/hello_world): Print "Hello world!". Used in [Extensions](https://docs.tilt.dev/extensions.html).
 - [`helm_remote`](https://github.com/tilt-dev/tilt-extensions/tree/master/helm_remote): Install a remote Helm chart (in a way that gets properly uninstalled when running `tilt down`)
+- [`honeycomb`](https://github.com/tilt-dev/tilt-extensions/tree/master/honeycomb): Report dev env health metrics to [Honeycomb](https://honeycomb.io).
 - [`jest_test_runner`](https://github.com/tilt-dev/tilt-extensions/tree/master/jest_test_runner): Jest JavaScript test runner. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
 - [`ko`](https://github.com/tilt-dev/tilt-extensions/tree/master/ko): Use [Ko](https://github.com/google/ko) to build Go-based container images
 - [`kubebuilder`](https://github.com/tilt-dev/tilt-extensions/tree/master/kubebuilder): Enable live-update for developing [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) projects.


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/honeycomb2:

7ee2db28a1caf6641cbe622063c18cfc39ad3c58 (2021-12-03 18:51:23 -0500)
docs: add honeycomb to api docs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics