### PR TITLE
site: remove jekyll-target-blank and replace it with our own check

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -24,7 +24,6 @@ group :jekyll_plugins do
   gem "jekyll-redirect-from"
   gem "jekyll-sitemap"
   gem "jekyll-seo-tag"
-  gem "jekyll-target-blank"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -5,16 +5,16 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.9)
-    em-websocket (0.5.2)
+    em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
+      http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.15.4)
     forwardable-extended (2.6.0)
-    http_parser.rb (0.6.0)
-    i18n (1.8.10)
+    http_parser.rb (0.8.0)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    jekyll (4.2.0)
+    jekyll (4.2.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -48,9 +48,6 @@ GEM
     jekyll-tagging-related_posts (1.1.0)
       jekyll (>= 3.5, < 5.0)
       jekyll-tagging (~> 1.0)
-    jekyll-target-blank (2.0.0)
-      jekyll (>= 3.0, < 5.0)
-      nokogiri (~> 1.10)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -72,7 +69,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    racc (1.5.2)
+    racc (1.6.0)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -99,11 +96,10 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   jekyll-tagging-related_posts
-  jekyll-target-blank
   kramdown (>= 2.3.1)
   minima (~> 2.0)
   rouge
   tzinfo-data
 
 BUNDLED WITH
-   2.2.28
+   2.2.32

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -25,6 +25,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;600&family=Fira+Sans:wght@200&display=swap" rel="stylesheet">
+  <script src="/assets/js/links.js" async></script>
 
   <noscript>
   <style>

--- a/src/_layouts/docs.html
+++ b/src/_layouts/docs.html
@@ -130,7 +130,6 @@ layout: docs-header
     </article>
   </div>
 
-  <script src="/assets/js/links.js" async></script>
   <script src="{{ '/assets/js/van11y-accessible-accordion-aria.min.js' | relative_url }}" defer></script>
   <script src="{{ '/assets/js/clipboard.min.js' | relative_url }}" defer></script>
   <script src="{{ '/assets/js/copy-code.js' | relative_url }}" defer></script>

--- a/src/assets/js/links.js
+++ b/src/assets/js/links.js
@@ -1,20 +1,33 @@
-// Adapted from
-// http://blog.parkermoore.de/2014/08/01/header-anchor-links-in-vanilla-javascript-for-github-pages-and-jekyll/
-
 (function() {
   const eventListener = () => {
     if (document.readyState !== "complete") {
       return
     }
 
-    const links = document.querySelectorAll('.Docs-content h2[id],.Docs-content h3[id]');
-    links.forEach(el => {
+    // Adapted from
+    // http://blog.parkermoore.de/2014/08/01/header-anchor-links-in-vanilla-javascript-for-github-pages-and-jekyll/
+    // Adds floading header anchors.
+    const headerLinks = document.querySelectorAll('.Docs-content h2[id],.Docs-content h3[id]');
+    headerLinks.forEach(el => {
       // wrap the header contents in a link so that the entire thing is clickable
       const link = document.createElement('a');
       link.href = '#' + el.id;
       link.innerHTML = el.innerHTML;
       el.innerHTML = link.outerHTML;
     })
+
+    // Add _target=_blank to external links.
+    const links = document.querySelectorAll('a')
+    links.forEach(el => {
+      let href = String(el.href)
+      if (href.indexOf('localhost') == -1 &&
+          href.indexOf('tilt.dev') == -1 &&
+          href.indexOf('github.com/tilt-dev/') == -1) {
+        el.target = "_blank"
+        el.rel = "noopener noreferrer"
+      }
+    })
+
     document.removeEventListener('readystatechange', eventListener)
   }
 


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/target-blank:

6f29bdf65c74b15e84ed8adcaaa0357f4c0bf181 (2021-12-07 16:20:56 -0500)
site: remove jekyll-target-blank and replace it with our own check
The jekyll-target-blank's definition of an "external" site is
non-customizable, and it doesn't seem like the upstream maintainers
are interested in fixing this.
https://github.com/keithmifsud/jekyll-target-blank/issues/45

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics