### PR TITLE
docs: add container_selector to k8s_custom_deploy api

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -312,7 +312,8 @@ def k8s_custom_deploy(name: str,
                       apply_cmd_bat: str="",
                       delete_dir: str="",
                       delete_env: Dict[str, str]={},
-                      delete_cmd_bat: str="") -> None:
+                      delete_cmd_bat: str="",
+                      container_selector: str="") -> None:
   """Deploy resources to Kubernetes using a custom command.
 
   For deployment tools that cannot output templated YAML for use with :meth:`k8s_yaml`
@@ -335,6 +336,12 @@ def k8s_custom_deploy(name: str,
   Port forwards and other behavior can be configured using :meth:`k8s_resource`
   using the ``name`` as specified here.
 
+  If ``live_update`` rules are specified, exactly one of ``image_selector`` or
+  ``container_selector`` must be specified to determine which container(s) are
+  eligible for in-place updates. ``image_selector`` will match containers based
+  on an image reference, while ``container_selector`` will match a single container
+  by name.
+
   Args:
     name: resource name to use in Tilt UI and for further customization via :meth:`k8s_resource`
     apply_cmd: command that deploys objects to the Kubernetes cluster
@@ -348,6 +355,7 @@ def k8s_custom_deploy(name: str,
     delete_dir: working directory for ``delete_cmd``
     delete_env: environment variables for ``delete_cmd``
     delete_cmd_bat: delete command to run, expressed as a Windows batch command
+    container_selector: container name to determine container for Live Update
   """
   pass
 

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -5350,6 +5350,24 @@ status code &gt;= 200 and &lt; 400.
              </span>
             </span>
            </em>
+           ,
+           <em class="sig-param">
+            <span class="n">
+             <span class="pre">
+              container_selector
+             </span>
+            </span>
+            <span class="o">
+             <span class="pre">
+              =
+             </span>
+            </span>
+            <span class="default_value">
+             <span class="pre">
+              &apos;&apos;
+             </span>
+            </span>
+           </em>
            <span class="sig-paren">
             )
            </span>
@@ -5492,6 +5510,42 @@ invoked, and objects might have already been deleted before
              </span>
             </code>
             as specified here.
+           </p>
+           <p>
+            If
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              live_update
+             </span>
+            </code>
+            rules are specified, exactly one of
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              image_selector
+             </span>
+            </code>
+            or
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              container_selector
+             </span>
+            </code>
+            must be specified to determine which container(s) are
+eligible for in-place updates.
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              image_selector
+             </span>
+            </code>
+            will match containers based
+on an image reference, while
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              container_selector
+             </span>
+            </code>
+            will match a single container
+by name.
            </p>
            <dl class="field-list simple">
             <dt class="field-odd">
@@ -5785,6 +5839,20 @@ invoked, and objects might have already been deleted before
                  </span>
                 </code>
                 ) &#x2013; delete command to run, expressed as a Windows batch command
+               </p>
+              </li>
+              <li>
+               <p>
+                <strong>
+                 container_selector
+                </strong>
+                (
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ) &#x2013; container name to determine container for Live Update
                </p>
               </li>
              </ul>


### PR DESCRIPTION
`container_selector` allows passing a container name instead of the
image to use for determining which container should be in-place
updated for Live Update.

This is useful for tools that have a predictable container name but
abstract the image details away from end users.

See tilt-dev/tilt#5248 for implementation.