### PR TITLE
Update listdir() documentation

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -699,7 +699,9 @@ def blob(contents: str) -> Blob:
 def listdir(directory: str, recursive: bool = False) -> List[str]:
   """Returns all the files of the provided directory.
 
-  If ``rescursive`` is set to ``True``, the directory's contents will be recursively watched, and a change to any file will trigger a re-execution of the Tiltfile.
+  If ``recursive`` is set to ``True``, the directory's contents will be recursively watched, and a change to any file will trigger a re-execution of the Tiltfile.
+
+  This function returns absolute paths. Subdirectory names are not returned.
 
   Args:
     directory: Path to the directory locally (absolute, or relative to the location of the Tiltfile).


### PR DESCRIPTION
There are important differences with Python which I think are worth highlighting.

* Subdirectory names are not returned, only file names
* This function returns absolute paths, not relative to the input like Python
* Also fix typo 'rescursive'