### PR TITLE
docs: Improve navigation for Tiltfile API section

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,66 @@ sidebar: reference
 
 Tiltfiles are written in _Starlark_, a dialect of Python. For more information on Starlark's built-ins, [see the **Starlark Spec**](https://github.com/bazelbuild/starlark/blob/master/spec.md). The rest of this page details Tiltfile-specific functionality.
 
+## Functions
+
+<ul>
+{% for name in site.data.api.functions.functions %}
+
+{% assign anchor = "api." | append: name %}
+{% if name contains "." %}
+  {% assign anchor = "modules." | append: name %}
+{% endif %}
+
+<li><a href="#{{anchor}}">{{ name }}</a></li>
+{% endfor %}
+</ul>
+
+---
+
+{% include api/functions.html %}
+
+---
+
+## Types
+
+<ul>
+{% for name in site.data.api.classes.classes %}
+
+{% assign anchor = "api." | append: name %}
+{% if name contains "." %}
+  {% assign anchor = "modules." | append: name %}
+{% endif %}
+  
+<li><a href="#{{anchor}}">{{ name }}</a></li>
+{% endfor %}
+</ul>
+
+---
+
+{% include api/classes.html %}
+
+---
+
+## Data
+
+<ul>
+{% for name in site.data.api.data.data %}
+
+{% assign anchor = "api." | append: name %}
+{% if name contains "." %}
+  {% assign anchor = "modules." | append: name %}
+{% endif %}
+
+<li><a href="#{{anchor}}">{{ name }}</a></li>
+{% endfor %}
+</ul>
+
+---
+
+{% include api/data.html %}
+
+---
+
 ## Extensions
 
 Can't find what you're looking for in this reference?
@@ -43,61 +103,3 @@ examples of what you can do with a Tiltfile. Load them into your own Tiltfile. I
 - [`snyk`](https://github.com/tilt-dev/tilt-extensions/tree/master/snyk): Use [Snyk](https://snyk.io) to test your containers, configuration files, and open source dependencies.
 - [`syncback`](https://github.com/tilt-dev/tilt-extensions/tree/master/syncback): Sync files/directories from your container back to your local FS.
 - [`wait_for_it`](https://github.com/tilt-dev/tilt-extensions/tree/master/wait_for_it): Wait until command output is equal to given output.
-
-## Data
-
-<ul>
-{% for name in site.data.api.data.data %}
-
-{% assign anchor = "api." | append: name %}
-{% if name contains "." %}
-  {% assign anchor = "modules." | append: name %}
-{% endif %}
-
-<li><a href="#{{anchor}}">{{ name }}</a></li>
-{% endfor %}
-</ul>
-
----
-
-{% include api/data.html %}
-
----
-
-## Functions
-
-<ul>
-{% for name in site.data.api.functions.functions %}
-
-{% assign anchor = "api." | append: name %}
-{% if name contains "." %}
-  {% assign anchor = "modules." | append: name %}
-{% endif %}
-  
-<li><a href="#{{anchor}}">{{ name }}</a></li>
-{% endfor %}
-</ul>
-
----
-
-{% include api/functions.html %}
-
----
-
-## Types
-
-<ul>
-{% for name in site.data.api.classes.classes %}
-
-{% assign anchor = "api." | append: name %}
-{% if name contains "." %}
-  {% assign anchor = "modules." | append: name %}
-{% endif %}
-  
-<li><a href="#{{anchor}}">{{ name }}</a></li>
-{% endfor %}
-</ul>
-
----
-
-{% include api/classes.html %}

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -160,9 +160,17 @@ sidebar:
       items:
       - title: Overview
         href: api.html
+      - title: Functions
+        href: api.html#functions
+      - title: Types
+        href: api.html#types
+      - title: Data
+        href: api.html#data
+      - title: Extensions
+        href: api.html#extensions
+    # Start Tilt CLI Reference
     - title: Tilt CLI Reference
       items:
-# Start Tilt CLI Reference
       - title: tilt
         href: cli/tilt.html
         info: Manages your microservices in development


### PR DESCRIPTION
Please review the following changes for the Tiltfile API section:

- Changed order of content from most to least used (assumed)
- Added navigation items to directly point to functions, types, data and extensions