### PR TITLE
docs: Improve access to language examples from sidebar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Tilt User Guide
+title: Getting Started With Tilt
 layout: docs
 sidebar: gettingstarted
 ---
@@ -19,7 +19,7 @@ up-to-date. Think `docker build && kubectl apply` or `docker-compose up`.
 ## Finding the right manual
 
 **Completely new to Tilt?**  
-Watch our two minute [video](#watch-tilt-in-two-minutes) explaining Tilt.  
+Watch our two minute [explanation video](#watch-tilt-in-two-minutes).  
 Then head over to our [tutorial](/tutorial) to run Tilt yourself for the very first time!
 
 **Setting up Tilt for existing services?**  

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,19 @@ Tilt automates all the steps from a code change to a new process: watching
 files, building container images, and bringing your environment
 up-to-date. Think `docker build && kubectl apply` or `docker-compose up`.
 
-## Finding the right manual
+# Get Tilt
+Installing the `tilt` binary is a one-step command.
 
+### macOS/Linux
+```bash
+curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+```
+### Windows
+```powershell
+iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.ps1'))
+```
+
+## Finding the right manual
 **Completely new to Tilt?**  
 Watch our two minute [explanation video](#watch-tilt-in-two-minutes).  
 Then head over to our [tutorial](/tutorial) to run Tilt yourself for the very first time!

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,35 +16,14 @@ Tilt automates all the steps from a code change to a new process: watching
 files, building container images, and bringing your environment
 up-to-date. Think `docker build && kubectl apply` or `docker-compose up`.
 
-## Watch: Tilt in Two Minutes
+## Finding the right manual
 
-<div class="Docs-video">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/FSMc3kQgd5Y?controls=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
+**Completely new to Tilt?**  
+Watch our two minute [video](#watch-tilt-in-two-minutes) explaining Tilt.  
+Then head over to our [tutorial](/tutorial) to run Tilt yourself for the very first time!
 
-## Install Tilt
-
-Installing the `tilt` binary is a one-step command.
-
-### macOS/Linux
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
-```
-
-### Windows
-
-```powershell
-iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.ps1'))
-```
-
-For specific package managers (Homebrew, Scoop, Conda, asdf), see the [Installation Guide](install.html).
-
-## Run Tilt
-
-**New to Tilt?** Our tutorial will [get you started](/tutorial).
-
-**Configuring a Service?** We have best practice guides for:
+**Setting up Tilt for existing services?**  
+We have best practice guides for:
 
 <ul>
   {% for page in site.data.examples %}
@@ -52,8 +31,16 @@ For specific package managers (Homebrew, Scoop, Conda, asdf), see the [Installat
   {% endfor %}
 </ul>
 
-**Optimizing a Tiltfile?** Search for the function you need in our 
-[complete API reference](api.html).
+**Optimizing your Tiltfile?**  
+Search for the function you need in our 
+[API reference](api.html).
+
+## Watch: Tilt in Two Minutes
+
+<div class="Docs-video">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/FSMc3kQgd5Y?controls=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>
+
 
 ## Community
 

--- a/docs/tiltfile_authoring.md
+++ b/docs/tiltfile_authoring.md
@@ -1,10 +1,9 @@
 ---
-title: "Tutorial: The First 15 Minutes"
+title: "Writing Your First Tiltfile"
 description: "This tutorial walks you through setting up Tilt for your project."
 layout: docs
 sidebar: guides
 ---
-
 This tutorial walks you through setting up Tilt for your project. 
 
 It should take 15 minutes, and assumes you've already [installed Tilt](install.html). Before you begin, you may want to join the `#tilt` channel in [Kubernetes Slack](http://slack.k8s.io) for technical and moral support.

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,6 +1,5 @@
 ---
-title: Overview
-subtitle: Tilt Tutorial
+title: First Look at Tilt
 layout: docs
 sidebar: gettingstarted
 permalink: /tutorial/index.html

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -19,9 +19,9 @@ top:
 
 sidebar:
   gettingstarted:
-  - title: Why Use Tilt?
+  - title: Learn About Tilt
     items:
-    - title: Overview
+    - title: Getting Started
       href: ""
     - title: The Control Loop
       href: controlloop.html

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -30,7 +30,7 @@ sidebar:
     - title: Local vs Remote Services
       href: local_vs_remote.html
 
-  - title: Tutorial
+  - title: First Look at Tilt
     inSectionNav: true
     items:
       - title: Overview

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -68,7 +68,7 @@ sidebar:
   guides:
     - title: Tiltfile
       items:
-        - title: Writing a Tiltfile
+        - title: Writing Your First Tiltfile
           href: tiltfile_authoring.html
         - title: Tiltfile Concepts
           href: tiltfile_concepts.html

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -83,6 +83,24 @@ sidebar:
         - title: Manual Update Control
           href: manual_update_control.html
 
+    - title: Migrating Existing Projects
+      items:
+        - title: Plain Old Static HTML
+          href: example_static_html.html
+        - title: Go
+          href: example_go.html
+        - title: Python
+          href: example_python.html
+        - title: NodeJS
+          href: example_nodejs.html
+        - title: Java
+          href: example_java.html
+        - title: Bazel
+          href: example_bazel.html
+        - title: C#
+          href: example_csharp.html
+
+
     - title: Building Images
       items:
         - title: Overview
@@ -119,20 +137,6 @@ sidebar:
       items:
         - title: Technical Specifications
           href: live_update_reference.html
-        - title: Plain Old Static HTML
-          href: example_static_html.html
-        - title: Go
-          href: example_go.html
-        - title: Python
-          href: example_python.html
-        - title: NodeJS
-          href: example_nodejs.html
-        - title: Java
-          href: example_java.html
-        - title: Bazel
-          href: example_bazel.html
-        - title: C#
-          href: example_csharp.html
 
     - title: Continuous Integration (CI)
       items:


### PR DESCRIPTION
Please review the following changes for the Guides section:

- added new "Migrating existing projects" section to make language examples more visible and remove unwanted association with the LiveUpdate feature