### PR TITLE
docs: Change nav to prioritize tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.co
 
 ## Finding the right manual
 **Completely new to Tilt?**  
-Watch our two minute [explanation video](#watch-tilt-in-two-minutes).  
+Watch our two minute [explanation video](#watch-tilt-in-two-minutes) and browse through [FAQs about Tilt](/product_faq).  
 Then head over to our [tutorial](/tutorial) to run Tilt yourself for the very first time!
 
 **Setting up Tilt for existing services?**  

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -23,6 +23,8 @@ sidebar:
     items:
     - title: Getting Started
       href: ""
+    - title: Is Tilt right for me?
+      href: product_faq.html
 
   - title: First Look at Tilt
     inSectionNav: true
@@ -59,8 +61,6 @@ sidebar:
 
   - title:  FAQs
     items:
-      - title: Is Tilt right for me?
-        href: product_faq.html
       - title: Frequently Asked Questions
         href: faq.html
       - title: Why is Tilt broken?

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -23,12 +23,6 @@ sidebar:
     items:
     - title: Getting Started
       href: ""
-    - title: The Control Loop
-      href: controlloop.html
-    - title: Choosing a Local Dev Cluster
-      href: choosing_clusters.html
-    - title: Local vs Remote Services
-      href: local_vs_remote.html
 
   - title: First Look at Tilt
     inSectionNav: true
@@ -52,6 +46,16 @@ sidebar:
       href: install.html
     - title: Upgrade
       href: upgrade.html
+
+  - title:  How Does Tilt Work?
+    items:
+    - title: The Control Loop
+      href: controlloop.html
+    - title: Choosing a Local Dev Cluster
+      href: choosing_clusters.html
+    - title: Local vs Remote Services
+      href: local_vs_remote.html
+
 
   - title:  FAQs
     items:

--- a/src/_data/github.yml
+++ b/src/_data/github.yml
@@ -1,2 +1,2 @@
-stars: 4.9k
+stars: 5.0k
 href: https://github.com/tilt-dev/tilt


### PR DESCRIPTION
@SurbhiSGupta asked to move some of the more "expert" articles to a section below the tutorial. 

<img width="1520" alt="2021-12-22 - Docs nav" src="https://user-images.githubusercontent.com/20349/147175141-55b946e5-5dd7-47c6-94b6-fc7a48794cff.png">

