### PR TITLE
netlify: don't open deploy preview links in new window

### DIFF
--- a/src/_data/github.yml
+++ b/src/_data/github.yml
@@ -1,2 +1,2 @@
-stars: 4.9k
+stars: 5.0k
 href: https://github.com/tilt-dev/tilt

--- a/src/assets/js/links.js
+++ b/src/assets/js/links.js
@@ -21,6 +21,7 @@
     links.forEach(el => {
       let href = String(el.href)
       if (href.indexOf('localhost') == -1 &&
+          href.indexOf('deploy-preview') == -1 &&
           href.indexOf('tilt.dev') == -1 &&
           href.indexOf('github.com/tilt-dev/') == -1) {
         el.target = "_blank"


### PR DESCRIPTION
Don't consider deploy preview links from Netlify as "external" links, so they don't open in a new window. This will make sure that the deploy previews behave like the site does in local dev and prod.