### PR TITLE
docs: add notes about restart_process' role in live_update

### DIFF
--- a/docs/example_csharp.md
+++ b/docs/example_csharp.md
@@ -224,12 +224,20 @@ docker_build_with_restart(
 The first thing to notice is the `live_update` parameter, which consists of one `sync` step.
 This copies the build output from the `out` directory into the container.
 
-After syncing the files, we want to re-execute our updated binary. We accomplish this with the
-[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process),
-which we imported with the `load` call on the first line. (For more on extensions, [see the docs](/extensions.html).)
+After syncing the files, we want to restart our updated binary. 
+
+In this example, we restart the binary with the
+[`restart_process` extension](https://github.com/tilt-dev/tilt-extensions/tree/master/restart_process),
+which we imported with the `load` call on the first line.
 We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
+
+The `restart_process` extension is a lowest-common-denominator reload
+tool. Tilt's `live_update` API tries to be flexible enough so that you can use
+native hot reload support if your framework supports it. We're always happy
+to accept examples of specific frameworks in [the example
+repo](https://github.com/tilt-dev/tilt-example-csharp).
 
 Let's see what this new configuration looks like in action:
 

--- a/docs/example_csharp.md
+++ b/docs/example_csharp.md
@@ -229,15 +229,15 @@ After syncing the files, we want to restart our updated binary.
 In this example, we restart the binary with the
 [`restart_process` extension](https://github.com/tilt-dev/tilt-extensions/tree/master/restart_process),
 which we imported with the `load` call on the first line.
-We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
+We swap out our `docker_build` call for the `docker_build_with_restart` function we imported: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
 
 The `restart_process` extension is a lowest-common-denominator reload
 tool. Tilt's `live_update` API tries to be flexible enough so that you can use
-native hot reload support if your framework supports it. We're always happy
-to accept examples of specific frameworks in [the example
-repo](https://github.com/tilt-dev/tilt-example-csharp).
+native hot reload support if your framework supports it. 
+If you have more examples for specific frameworks, we'd be happy to add them to
+[the example repo](https://github.com/tilt-dev/tilt-example-csharp).
 
 Let's see what this new configuration looks like in action:
 

--- a/docs/example_go.md
+++ b/docs/example_go.md
@@ -252,15 +252,15 @@ After syncing the files, we want to restart our updated binary.
 In this example, we restart the binary with the
 [`restart_process` extension](https://github.com/tilt-dev/tilt-extensions/tree/master/restart_process),
 which we imported with the `load` call on the first line.
-We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
+We swap out our `docker_build` call for the `docker_build_with_restart` function we imported: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
 
 The `restart_process` extension is a lowest-common-denominator reload
 tool. Tilt's `live_update` API tries to be flexible enough so that you can use
-native hot reload support if your framework supports it. We're always happy
-to accept examples of specific frameworks in [the example
-repo](https://github.com/tilt-dev/tilt-example-go).
+native hot reload support if your framework supports it. 
+If you have more examples for specific frameworks, we'd be happy to add them to
+[the example repo](https://github.com/tilt-dev/tilt-example-go).
 
 Let's see what this new configuration looks like in action:
 

--- a/docs/example_go.md
+++ b/docs/example_go.md
@@ -247,12 +247,20 @@ docker_build_with_restart(
 The first thing to notice is the `live_update` parameter, which consists of two `sync`
 steps. They copy the code from the `./build` and `./web` directories into the container.
 
-After syncing the files, we want to re-execute our updated binary. We accomplish this with the
-[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process),
-which we imported with the `load` call on the first line. (For more on extensions, [see the docs](/extensions.html).)
+After syncing the files, we want to restart our updated binary. 
+
+In this example, we restart the binary with the
+[`restart_process` extension](https://github.com/tilt-dev/tilt-extensions/tree/master/restart_process),
+which we imported with the `load` call on the first line.
 We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
+
+The `restart_process` extension is a lowest-common-denominator reload
+tool. Tilt's `live_update` API tries to be flexible enough so that you can use
+native hot reload support if your framework supports it. We're always happy
+to accept examples of specific frameworks in [the example
+repo](https://github.com/tilt-dev/tilt-example-go).
 
 Let's see what this new configuration looks like in action:
 

--- a/docs/example_java.md
+++ b/docs/example_java.md
@@ -323,12 +323,20 @@ The first thing to notice is the `live_update` parameter, which consists of some
 They copy the library and compiled `.class `files from the `./build/jar`
 directory into the container.
 
-After syncing the files, we want to re-execute our updated binary. We accomplish this with the
-[`restart_process` extension](https://github.com/windmilleng/tilt-extensions/tree/master/restart_process),
-which we imported with the `load` call on the first line. (For more on extensions, [see the docs](/extensions.html).)
+After syncing the files, we want to restart our updated binary. 
+
+In this example, we restart the binary with the
+[`restart_process` extension](https://github.com/tilt-dev/tilt-extensions/tree/master/restart_process),
+which we imported with the `load` call on the first line.
 We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
+
+The `restart_process` extension is a lowest-common-denominator reload
+tool. Tilt's `live_update` API tries to be flexible enough so that you can use
+native hot reload support if your framework supports it. We're always happy
+to accept examples of specific frameworks in [the example
+repo](https://github.com/tilt-dev/tilt-example-java).
 
 Lastly, our `local_resource` first unzips the jar to `build/jar-staging`, and
 then uses `rsync --checksum` to copy that to `build/jar`.

--- a/docs/example_java.md
+++ b/docs/example_java.md
@@ -328,15 +328,15 @@ After syncing the files, we want to restart our updated binary.
 In this example, we restart the binary with the
 [`restart_process` extension](https://github.com/tilt-dev/tilt-extensions/tree/master/restart_process),
 which we imported with the `load` call on the first line.
-We swap out our `docker_build` call for function we imported, `docker_build_with_restart`: it's
+We swap out our `docker_build` call for the `docker_build_with_restart` function we imported: it's
 almost exactly the same as `docker_build`, only it knows to restart our process at the end
 of a `live_update`. The `entrypoint` parameter specifies what command to re-execute.
 
 The `restart_process` extension is a lowest-common-denominator reload
 tool. Tilt's `live_update` API tries to be flexible enough so that you can use
-native hot reload support if your framework supports it. We're always happy
-to accept examples of specific frameworks in [the example
-repo](https://github.com/tilt-dev/tilt-example-java).
+native hot reload support if your framework supports it. 
+If you have more examples for specific frameworks, we'd be happy to add them to
+[the example repo](https://github.com/tilt-dev/tilt-example-java).
 
 Lastly, our `local_resource` first unzips the jar to `build/jar-staging`, and
 then uses `rsync --checksum` to copy that to `build/jar`.


### PR DESCRIPTION
Hello @lianmakesthings,

Please review the following commits I made in branch nicks/liveupdate:

536973ce8f877ea195b1941f78d7c04a05829c55 (2021-12-23 14:03:14 -0500)
docs: add notes about restart_process' role in live_update

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics