### PR TITLE
docs: document List[str] possibility for all commands

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1058,7 +1058,7 @@ def allow_k8s_contexts(contexts: Union[str, List[str]]) -> None:
   pass
 
 def enable_feature(feature_name: str) -> None:
-  """Configures Tilt to enable non-default features (e.g.,  or deprecated).
+  """Configures Tilt to enable non-default features (e.g., experimental or deprecated).
 
   The Tilt features controlled by this are generally in an unfinished state, and
   not yet documented.

--- a/api/api.py
+++ b/api/api.py
@@ -148,7 +148,7 @@ def sync(local_path: str, remote_path: str) -> LiveUpdateStep:
   """
   pass
 
-def run(cmd: str, trigger: Union[List[str], str] = []) -> LiveUpdateStep:
+def run(cmd: Union[str, List[str]], trigger: Union[List[str], str] = []) -> LiveUpdateStep:
   """Specify that the given `cmd` should be executed when updating an image's container
 
   May not precede any `sync` steps in a `live_update`.
@@ -156,7 +156,9 @@ def run(cmd: str, trigger: Union[List[str], str] = []) -> LiveUpdateStep:
   For more info, see the `Live Update Reference <live_update_reference.html>`_.
 
   Args:
-    cmd: A shell command.
+    cmd: Command to run. If a string, executed with ``sh -c``; if a list, will be passed to the operating system
+      as program name and args.
+
     trigger: If the ``trigger`` argument is specified, the build step is only run when there are changes to the given file(s). Paths relative to Tiltfile. (Note that in addition to matching the trigger, file changes must also match at least one of this Live Update's syncs in order to trigger this run. File changes that do not match any syncs will be ignored.)
   """
   pass
@@ -319,10 +321,10 @@ def k8s_custom_deploy(name: str,
                       live_update: List[LiveUpdateStep]=[],
                       apply_dir: str="",
                       apply_env: Dict[str, str]={},
-                      apply_cmd_bat: str="",
+                      apply_cmd_bat: Union[str, List[str]]="",
                       delete_dir: str="",
                       delete_env: Dict[str, str]={},
-                      delete_cmd_bat: str="",
+                      delete_cmd_bat: Union[str, List[str]]="",
                       container_selector: str="",
                       image_deps: List[str]=[]) -> None:
   """Deploy resources to Kubernetes using a custom command.
@@ -355,17 +357,23 @@ def k8s_custom_deploy(name: str,
 
   Args:
     name: resource name to use in Tilt UI and for further customization via :meth:`k8s_resource`
-    apply_cmd: command that deploys objects to the Kubernetes cluster
-    delete_cmd: command that deletes objects in the Kubernetes cluster
+    apply_cmd: command that deploys objects to the Kubernetes cluster. If a string, executed with ``sh -c``
+      on macOS/Linux, or ``cmd /S /C`` on Windows; if a list, will be passed to the operating system as program name and args.
+    delete_cmd: command that deletes objects in the Kubernetes cluster. If a string, executed with ``sh -c``
+      on macOS/Linux, or ``cmd /S /C`` on Windows; if a list, will be passed to the operating system as program name and args.
     deps: paths to watch and trigger a re-apply on change
     image_selector: image reference to determine containers eligible for Live Update
     live_update: set of steps for updating a running container (see `Live Update documentation <live_update_reference.html>`_).
     apply_dir: working directory for ``apply_cmd``
     apply_env: environment variables for ``apply_cmd``
-    apply_cmd_bat: apply command to run, expressed as a Windows batch command
+    apply_cmd_bat: If non-empty and on Windows, takes precedence over ``apply_cmd``. Ignored on other platforms.
+      If a string, executed as a Windows batch command executed with ``cmd /S /C``; if a list, will be passed to
+      the operating system as program name and args.
     delete_dir: working directory for ``delete_cmd``
     delete_env: environment variables for ``delete_cmd``
-    delete_cmd_bat: delete command to run, expressed as a Windows batch command
+    delete_cmd_bat: If non-empty and on Windows, takes precedence over ``delete_cmd``. Ignored on other platforms.
+      If a string, executed as a Windows batch command executed with ``cmd /S /C``; if a list, will be passed to
+      the operating system as program name and args.
     container_selector: container name to determine container for Live Update
     image_deps: a list of image builds that this deploy depends on.
       The tagged image names will be injected into the environment of the
@@ -648,17 +656,19 @@ def load_dynamic(path: str) -> Dict[str, Any]:
 
 def local(command: Union[str, List[str]],
           quiet: bool = False,
-          command_bat: str = "",
+          command_bat: Union[str, List[str]] = "",
           echo_off: bool = False,
           env: Dict[str, str] = {},
           dir: str = "") -> Blob:
   """Runs a command on the *host* machine, waits for it to finish, and returns its stdout as a ``Blob``
 
   Args:
-    command: Command to run. If a string, executed with ``sh -c`` on macOS/Linux, or ``cmd /S /C`` on Windows; if a list, will be passed to the operating system as program name and args.
+    command: Command to run. If a string, executed with ``sh -c`` on macOS/Linux, or ``cmd /S /C`` on Windows;
+      if a list, will be passed to the operating system as program name and args.
     quiet: If set to True, skips printing output to log.
-    command_bat: The command to run, expressed as a Windows batch command executed
-      with ``cmd /S /C``. Takes precedence over the ``command`` parameter on Windows. Ignored on macOS/Linux.
+    command_bat: If non-empty and on Windows, takes precedence over ``command``. Ignored on other platforms.
+      If a string, executed as a Windows batch command executed with ``cmd /S /C``; if a list, will be passed to
+      the operating system as program name and args.
     echo_off: If set to True, skips printing command to log.
     env: Environment variables to pass to the executed ``command``. Values specified here will override any variables passed to the Tilt parent process.
     dir: Working directory for ``command``. Defaults to the Tiltfile's location.
@@ -894,7 +904,7 @@ def default_registry(host: str, host_from_cluster: str = None, single_name: str 
 
 def custom_build(
     ref: str,
-    command: str,
+    command: Union[str, List[str]],
     deps: List[str],
     tag: str = "",
     disable_push: bool = False,
@@ -905,7 +915,7 @@ def custom_build(
     entrypoint: Union[str, List[str]] = [],
     command_bat_val: str = "",
     outputs_image_ref_to: str = "",
-    command_bat: str = "",
+    command_bat: Union[str, List[str]] = "",
     image_deps: List[str] = []):
   """Provide a custom command that will build an image.
 
@@ -928,7 +938,9 @@ def custom_build(
 
   Args:
     ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'). If this image will be used in a k8s resource(s), this ref must match the ``spec.container.image`` param for that resource(s).
-    command: a command that, when run in the shell, builds an image puts it in the registry as ``ref``. In the default mode, must produce an image named ``$EXPECTED_REF``.  Executed with ``sh -c`` on macOS/Linux, or ``cmd /S /C`` on Windows.
+    command: a command that, when run in the shell, builds an image puts it in the registry as ``ref``. In the
+      default mode, must produce an image named ``$EXPECTED_REF``.  If a string, executed with ``sh -c`` on macOS/Linux,
+      or ``cmd /S /C`` on Windows; if a list, will be passed to the operating system as program name and args.
     deps: a list of files or directories to be added as dependencies to this image. Tilt will watch those files and will rebuild the image when they change. Only accepts real paths, not file globs.
     tag: Some tools can't change the image tag at runtime. They need a pre-specified tag. Tilt will set ``$EXPECTED_REF = image_name:tag``,
        then re-tag it with its own tag before pushing to your cluster.
@@ -942,8 +954,9 @@ def custom_build(
     outputs_image_ref_to: Specifies a file path. When set, the custom build command must write a content-based
       tagged image ref to this file. Tilt will read that file after the cmd runs to get the image ref,
       and inject that image ref into the YAML. For more on content-based tags, see <custom_build.html#why-tilt-uses-immutable-tags>_
-    command_bat: The command to run, expressed as a Windows batch command executed
-      with ``cmd /S /C``. Takes precedence over the ``command`` parameter on Windows. Ignored on macOS/Linux.
+    command_bat: If non-empty and on Windows, takes precedence over ``command``. Ignored on other platforms.
+      If a string, executed as a Windows batch command executed with ``cmd /S /C``; if a list, will be passed to
+      the operating system as program name and args.
     image_deps: a list of image builds that this deploy depends on.
       The tagged image names will be injected into the environment of the
       the custom build command in the form:
@@ -1045,7 +1058,7 @@ def allow_k8s_contexts(contexts: Union[str, List[str]]) -> None:
   pass
 
 def enable_feature(feature_name: str) -> None:
-  """Configures Tilt to enable non-default features (e.g., experimental or deprecated).
+  """Configures Tilt to enable non-default features (e.g.,  or deprecated).
 
   The Tilt features controlled by this are generally in an unfinished state, and
   not yet documented.
@@ -1062,12 +1075,16 @@ def enable_feature(feature_name: str) -> None:
   """
   pass
 
-def local_resource(name: str, cmd: Union[str, List[str]],
+def local_resource(name: str,
+                   cmd: Union[str, List[str]],
                    deps: Union[str, List[str]] = None,
                    trigger_mode: TriggerMode = TRIGGER_MODE_AUTO,
-                   resource_deps: List[str] = [], ignore: Union[str, List[str]] = [],
-                   auto_init: bool=True, serve_cmd: str = "", cmd_bat: str = "",
-                   serve_cmd_bat: str = "",
+                   resource_deps: List[str] = [],
+                   ignore: Union[str, List[str]] = [],
+                   auto_init: bool=True,
+                   serve_cmd: Union[str, List[str]] = "",
+                   cmd_bat: Union[str, List[str]] = "",
+                   serve_cmd_bat: Union[str, List[str]] = "",
                    allow_parallel: bool=False,
                    links: Union[str, Link, List[Union[str, Link]]]=[],
                    tags: List[str] = [],
@@ -1101,12 +1118,15 @@ def local_resource(name: str, cmd: Union[str, List[str]],
     ignore: set of file patterns that will be ignored. Ignored files will not trigger runs. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns will be evaluated relative to the Tiltfile.
     auto_init: whether this resource runs on ``tilt up``. Defaults to ``True``. For more info, see the
       `Manual Update Control docs <manual_update_control.html>`_.
-    serve_cmd: Tilt will run this command on update and expect it to not exit.
-      Executed with ``sh -c`` on macOS/Linux, or ``cmd /S /C`` on Windows.
-    cmd_bat: The command to run, expressed as a Windows batch command executed
-      with ``cmd /S /C``. Takes precedence over the ``cmd`` parameter on Windows. Ignored on macOS/Linux.
-    serve_cmd_bat: The command to run, expressed as a Windows batch command executed
-      with ``cmd /S /C``. Takes precedence over the ``serve_cmd`` parameter on Windows. Ignored on macOS/Linux.
+    serve_cmd: Tilt will run this command on update and expect it to not exit. If a string, executed with
+      ``sh -c`` on macOS/Linux, or ``cmd /S /C`` on Windows; if a list, will be passed to the operating
+      system as program name and args.
+    cmd_bat: If non-empty and on Windows, takes precedence over ``cmd``. Ignored on other platforms.
+      If a string, executed as a Windows batch command executed with ``cmd /S /C``; if a list, will be passed to
+      the operating system as program name and args.
+    serve_cmd_bat: If non-empty and on Windows, takes precedence over ``serve_cmd``. Ignored on other platforms.
+      If a string, executed as a Windows batch command executed with ``cmd /S /C``; if a list, will be passed to
+      the operating system as program name and args.
     allow_parallel: By default, all local resources are presumed unsafe to run in parallel, due to race
       conditions around modifying a shared file system. Set to True to allow them to run in parallel.
     links: one or more links to be associated with this resource in the Web UI (e.g. perhaps you have a "reset database" workflow and want to attach a link to the database web console). Provide one or more strings (the URLs to link to) or :class:`~api.Link` objects.

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -3585,7 +3585,7 @@ and not in the
           </dt>
           <dd>
            <p>
-            Configures Tilt to enable non-default features (e.g.,  or deprecated).
+            Configures Tilt to enable non-default features (e.g., experimental or deprecated).
            </p>
            <p>
             The Tilt features controlled by this are generally in an unfinished state, and

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -586,24 +586,43 @@ of each mode. The guide has some examples of common combinations.
                  command
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; a command that, when run in the shell, builds an image puts it in the registry as
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; a command that, when run in the shell, builds an image puts it in the registry as
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   ref
                  </span>
                 </code>
-                . In the default mode, must produce an image named
+                . In the
+default mode, must produce an image named
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   $EXPECTED_REF
                  </span>
                 </code>
-                .  Executed with
+                .  If a string, executed with
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   sh
@@ -612,7 +631,8 @@ of each mode. The guide has some examples of common combinations.
                   -c
                  </span>
                 </code>
-                on macOS/Linux, or
+                on macOS/Linux,
+or
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   cmd
@@ -624,7 +644,7 @@ of each mode. The guide has some examples of common combinations.
                   /C
                  </span>
                 </code>
-                on Windows.
+                on Windows; if a list, will be passed to the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -934,13 +954,37 @@ and inject that image ref into the YAML. For more on content-based tags, see &lt
                  command_bat
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; The command to run, expressed as a Windows batch command executed
-with
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; If non-empty and on Windows, takes precedence over
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  command
+                 </span>
+                </code>
+                . Ignored on other platforms.
+If a string, executed as a Windows batch command executed with
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   cmd
@@ -952,13 +996,8 @@ with
                   /C
                  </span>
                 </code>
-                . Takes precedence over the
-                <code class="docutils literal notranslate">
-                 <span class="pre">
-                  command
-                 </span>
-                </code>
-                parameter on Windows. Ignored on macOS/Linux.
+                ; if a list, will be passed to
+the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -3546,7 +3585,7 @@ and not in the
           </dt>
           <dd>
            <p>
-            Configures Tilt to enable non-default features (e.g., experimental or deprecated).
+            Configures Tilt to enable non-default features (e.g.,  or deprecated).
            </p>
            <p>
             The Tilt features controlled by this are generally in an unfinished state, and
@@ -5709,7 +5748,28 @@ by name.
                   str
                  </span>
                 </code>
-                ]]) &#x2013; command that deploys objects to the Kubernetes cluster
+                ]]) &#x2013; command that deploys objects to the Kubernetes cluster. If a string, executed with
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  sh
+                 </span>
+                 <span class="pre">
+                  -c
+                 </span>
+                </code>
+                on macOS/Linux, or
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  cmd
+                 </span>
+                 <span class="pre">
+                  /S
+                 </span>
+                 <span class="pre">
+                  /C
+                 </span>
+                </code>
+                on Windows; if a list, will be passed to the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -5741,7 +5801,28 @@ by name.
                   str
                  </span>
                 </code>
-                ]]) &#x2013; command that deletes objects in the Kubernetes cluster
+                ]]) &#x2013; command that deletes objects in the Kubernetes cluster. If a string, executed with
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  sh
+                 </span>
+                 <span class="pre">
+                  -c
+                 </span>
+                </code>
+                on macOS/Linux, or
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  cmd
+                 </span>
+                 <span class="pre">
+                  /S
+                 </span>
+                 <span class="pre">
+                  /C
+                 </span>
+                </code>
+                on Windows; if a list, will be passed to the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -5875,12 +5956,50 @@ by name.
                  apply_cmd_bat
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; apply command to run, expressed as a Windows batch command
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; If non-empty and on Windows, takes precedence over
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  apply_cmd
+                 </span>
+                </code>
+                . Ignored on other platforms.
+If a string, executed as a Windows batch command executed with
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  cmd
+                 </span>
+                 <span class="pre">
+                  /S
+                 </span>
+                 <span class="pre">
+                  /C
+                 </span>
+                </code>
+                ; if a list, will be passed to
+the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -5939,12 +6058,50 @@ by name.
                  delete_cmd_bat
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; delete command to run, expressed as a Windows batch command
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; If non-empty and on Windows, takes precedence over
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  delete_cmd
+                 </span>
+                </code>
+                . Ignored on other platforms.
+If a string, executed as a Windows batch command executed with
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  cmd
+                 </span>
+                 <span class="pre">
+                  /S
+                 </span>
+                 <span class="pre">
+                  /C
+                 </span>
+                </code>
+                ; if a list, will be passed to
+the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -8122,7 +8279,8 @@ you don&#x2019;t get the nice syntactic sugar of binding local variables.
                   /C
                  </span>
                 </code>
-                on Windows; if a list, will be passed to the operating system as program name and args.
+                on Windows;
+if a list, will be passed to the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -8145,13 +8303,37 @@ you don&#x2019;t get the nice syntactic sugar of binding local variables.
                  command_bat
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; The command to run, expressed as a Windows batch command executed
-with
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; If non-empty and on Windows, takes precedence over
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  command
+                 </span>
+                </code>
+                . Ignored on other platforms.
+If a string, executed as a Windows batch command executed with
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   cmd
@@ -8163,13 +8345,8 @@ with
                   /C
                  </span>
                 </code>
-                . Takes precedence over the
-                <code class="docutils literal notranslate">
-                 <span class="pre">
-                  command
-                 </span>
-                </code>
-                parameter on Windows. Ignored on macOS/Linux.
+                ; if a list, will be passed to
+the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -8919,13 +9096,30 @@ See the
                  serve_cmd
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; Tilt will run this command on update and expect it to not exit.
-Executed with
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; Tilt will run this command on update and expect it to not exit. If a string, executed with
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   sh
@@ -8946,7 +9140,8 @@ Executed with
                   /C
                  </span>
                 </code>
-                on Windows.
+                on Windows; if a list, will be passed to the operating
+system as program name and args.
                </p>
               </li>
               <li>
@@ -8955,13 +9150,37 @@ Executed with
                  cmd_bat
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; The command to run, expressed as a Windows batch command executed
-with
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; If non-empty and on Windows, takes precedence over
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  cmd
+                 </span>
+                </code>
+                . Ignored on other platforms.
+If a string, executed as a Windows batch command executed with
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   cmd
@@ -8973,13 +9192,8 @@ with
                   /C
                  </span>
                 </code>
-                . Takes precedence over the
-                <code class="docutils literal notranslate">
-                 <span class="pre">
-                  cmd
-                 </span>
-                </code>
-                parameter on Windows. Ignored on macOS/Linux.
+                ; if a list, will be passed to
+the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -8988,13 +9202,37 @@ with
                  serve_cmd_bat
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; The command to run, expressed as a Windows batch command executed
-with
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; If non-empty and on Windows, takes precedence over
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  serve_cmd
+                 </span>
+                </code>
+                . Ignored on other platforms.
+If a string, executed as a Windows batch command executed with
                 <code class="docutils literal notranslate">
                  <span class="pre">
                   cmd
@@ -9006,13 +9244,8 @@ with
                   /C
                  </span>
                 </code>
-                . Takes precedence over the
-                <code class="docutils literal notranslate">
-                 <span class="pre">
-                  serve_cmd
-                 </span>
-                </code>
-                parameter on Windows. Ignored on macOS/Linux.
+                ; if a list, will be passed to
+the operating system as program name and args.
                </p>
               </li>
               <li>
@@ -10820,12 +11053,40 @@ see the
                  cmd
                 </strong>
                 (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
                 <code class="xref py py-class docutils literal notranslate">
                  <span class="pre">
                   str
                  </span>
                 </code>
-                ) &#x2013; A shell command.
+                ,
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]]) &#x2013; Command to run. If a string, executed with
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  sh
+                 </span>
+                 <span class="pre">
+                  -c
+                 </span>
+                </code>
+                ; if a list, will be passed to the operating system
+as program name and args.
                </p>
               </li>
               <li>


### PR DESCRIPTION
1. Make sure that command parameters that accept `Union[str | List[str]]` are documented as such. (I went by calls to `ValueGroupToCmdHelper` and `ValueToUnixCmd`, but maybe there are others?)
2. Make the language around command/bat param interaction a bit more consistent.