### PR TITLE
docs: fix right margin in api code blocks

### DIFF
--- a/src/_sass/api.scss
+++ b/src/_sass/api.scss
@@ -72,9 +72,3 @@ dl:not(.class) > dt {
 dt:hover .headerlink::after {
   opacity: 1;
 }
-
-// Sphinx adds spaces after every literal,
-// so add negative spacing to tighten up the text.
-.docutils.literal {
-  margin-right: -0.33em;
-}

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -358,6 +358,9 @@ $sidebar-maximum-width: 400px;
   border-radius: $tilt2-border-radius-large;
   padding-left: $spacing-unit * 0.2;
   padding-right: $spacing-unit * 0.2;
+  // shrink to size of any children.
+  // without this, we get extra space on the right.
+  display: inline-block;
 }
 
 // Cute callouts!


### PR DESCRIPTION
### Before
The negative margin extends the code block border over the next character (which is not in the code block), e.g.:
![image](https://user-images.githubusercontent.com/7453991/148424185-a91b7f9b-323f-4002-9439-dba104ba32fd.png)
![image](https://user-images.githubusercontent.com/7453991/148424215-ac871874-3008-44dc-9999-fff638b8600d.png)

### After
![image](https://user-images.githubusercontent.com/7453991/148424260-d2b74246-7263-4f15-9933-5ccd6b5f715f.png)
![image](https://user-images.githubusercontent.com/7453991/148424270-c214209e-ffa6-431f-bf85-1bf9359c9618.png)

I spent a bit reading docs and haven't managed to understand the underlying issue (why is it an issue on the right but not the left? does this affect other sphinx projects?) or why this solves it (most pages I found discussing inline vs inline block indicated only differences that don't apply here, though I did find lots of handwavy references to inline-block changing the way padding is calculated wrt parent elements). It seems to work and I'm guessing it's not worth more investigation at the moment.