### PR TITLE
docs: extend docker_build docs

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -218,6 +218,8 @@ def docker_build(ref: str,
 
   When using Docker Compose, Tilt expects the image build to be either managed by your Docker Compose file (via the `image <https://docs.docker.com/compose/compose-file/compose-file-v3/#build>`_ key) OR by Tilt's :meth:`docker_build`, but not both. (Follow this `GitHub issue <https://github.com/tilt-dev/tilt/issues/5196>`_ to be notified of changes to this expectation.)
 
+  Finally, Tilt will push the built image to a local image registry if one exists or to docker.io by default. Tilt can detect if you are using Docker for Desktop or Minikube and omit pushing.
+
   Args:
     ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'). If this image will be used in a k8s resource(s), this ref must match the ``spec.container.image`` param for that resource(s).
     context: path to use as the Docker build context.

--- a/api/api.py
+++ b/api/api.py
@@ -218,7 +218,7 @@ def docker_build(ref: str,
 
   When using Docker Compose, Tilt expects the image build to be either managed by your Docker Compose file (via the `image <https://docs.docker.com/compose/compose-file/compose-file-v3/#build>`_ key) OR by Tilt's :meth:`docker_build`, but not both. (Follow this `GitHub issue <https://github.com/tilt-dev/tilt/issues/5196>`_ to be notified of changes to this expectation.)
 
-  Finally, Tilt will push the built image to a local image registry if one exists or to docker.io by default. Tilt can detect if you are using Docker for Desktop or Minikube and omit pushing.
+  Finally, Tilt will put the image in a place where the target runtime can access it. Tilt will make a best effort to detect what kind of runtime you're using (Docker Compose, Kind, GKE, etc), and pick the best strategy for getting the image into it fast. See https://docs.tilt.dev/choosing_clusters.html for more info.
 
   Args:
     ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'). If this image will be used in a k8s resource(s), this ref must match the ``spec.container.image`` param for that resource(s).

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -2465,7 +2465,11 @@ ensures a pretty high bar of intent.
             to be notified of changes to this expectation.)
            </p>
            <p>
-            Finally, Tilt will push the built image to a local image registry if one exists or to docker.io by default. Tilt can detect if you are using Docker for Desktop or Minikube and omit pushing.
+            Finally, Tilt will put the image in a place where the target runtime can access it. Tilt will make a best effort to detect what kind of runtime you&#x2019;re using (Docker Compose, Kind, GKE, etc), and pick the best strategy for getting the image into it fast. See
+            <a class="reference external" href="https://docs.tilt.dev/choosing_clusters.html">
+             https://docs.tilt.dev/choosing_clusters.html
+            </a>
+            for more info.
            </p>
            <dl class="field-list simple">
             <dt class="field-odd">

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -2464,6 +2464,9 @@ ensures a pretty high bar of intent.
             </a>
             to be notified of changes to this expectation.)
            </p>
+           <p>
+            Finally, Tilt will push the built image to a local image registry if one exists or to docker.io by default. Tilt can detect if you are using Docker for Desktop or Minikube and omit pushing.
+           </p>
            <dl class="field-list simple">
             <dt class="field-odd">
              Parameters


### PR DESCRIPTION
Hi @nicks @milas,

could you please review the following changes I made to the docs:
- Added a bit in the docker_build section to inform user that this builtin will also push to an image registry in some instances