### PR TITLE
docs: add support for tags in docs menu and page titles

### DIFF
--- a/docs/disable_resources.md
+++ b/docs/disable_resources.md
@@ -3,9 +3,10 @@ title: Disabling Resources Through Tilt
 description: "Use Tilt's new feature to disable and enable resources through the UI. Manage what resources you have up and running more seamlessly."
 layout: docs
 sidebar: guides
+pilltag: beta
 ---
 
-> <span class="pill-tag">Beta</span> This feature is in beta. It's turned off by default, and breaking changes could be introduced while under development.
+> 💡 This feature is in beta. It's turned off by default, and breaking changes could be introduced while under development.
 
 Through Tilt’s UI Dashboard, you can enable and disable resources that are available in your Tilt session.
 

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -14,7 +14,6 @@ top:
   - title: Tilt API
     href: https://api.tilt.dev
     hrefMobile: https://api.tilt.dev
-    flair: new
 
 
 sidebar:
@@ -88,6 +87,7 @@ sidebar:
           href: manual_update_control.html
         - title: Disabling Resources
           href: disable_resources.html
+          pilltag: beta
 
     - title: Migrating Existing Projects
       items:

--- a/src/_layouts/docs-mobile-nav.html
+++ b/src/_layouts/docs-mobile-nav.html
@@ -15,8 +15,8 @@ layout: docs-header
               href="{{link.hrefMobile | escape}}">
               {{link.title | escape}}
             </a>
-            {% if link.flair %}
-              <div class="Docs-nav-link-flair">{{link.flair | escape}}</div>
+            {% if link.pilltag %}
+              <span class="pill-tag pill-tag--small pill-tag--right">{{link.pilltag | escape}}</span>
             {% endif %}
           </li>
         {% endfor %}
@@ -48,6 +48,9 @@ layout: docs-header
           {% assign pages = section.items %}
           <dt class="js-accordion__header Docs-subnav-title" data-accordion-opened="true">
             {{ section.title | escape }}
+            {% if section.pilltag %}
+              <span class="pill-tag pill-tag--small pill-tag--right">{{section.pilltag | escape}}</span>
+            {% endif %}
             {% svg assets/svg/carrot-down.svg %}
           </dt>
           <dd class="js-accordion__panel Docs-subnav-section">
@@ -57,6 +60,9 @@ layout: docs-header
                   <li class="js-accordion Docs-subnav-section-list-item Docs-subnav-subsection" data-accordion-prefix-classes="Docs-subnav">
                     <dt class="js-accordion__header Docs-subnav-title" data-accordion-opened="false">
                       {{ page.title | escape }}
+                      {% if page.pilltag %}
+                        <span class="pill-tag pill-tag--small pill-tag--right">{{page.pilltag | escape}}</span>
+                      {% endif %}
                       {% svg assets/svg/carrot-down.svg %}
                     </dt>
                     <dd class="js-accordion__panel Docs-subnav-section Docs-subnav-subsection">
@@ -65,6 +71,9 @@ layout: docs-header
                         <li class="Docs-subnav-section-list-item">
                           <a class="Docs-subnav-link{% if page_href == subpage.href %} is-active{% endif %}" href="/{{subpage.href | escape}}" onclick="highlightSubnav(this.href)">
                             {{ subpage.title | escape }}
+                            {% if subpage.pilltag %}
+                              <span class="pill-tag pill-tag--small">{{subpage.pilltag | escape}}</span>
+                            {% endif %}
                           </a>
                         </li>
                       {% endfor %}
@@ -74,6 +83,9 @@ layout: docs-header
                   <li class="Docs-subnav-section-list-item">
                     <a class="Docs-subnav-link{% if page_href == page.href %} is-active{% endif %}" href="/{{page.href | escape}}" onclick="highlightSubnav(this.href)">
                       {{ page.title | escape }}
+                      {% if page.pilltag %}
+                        <span class="pill-tag pill-tag--small pill-tag--right">{{page.pilltag | escape}}</span>
+                      {% endif %}
                     </a>
                   </li>
                 {% endif %}

--- a/src/_layouts/docs.html
+++ b/src/_layouts/docs.html
@@ -15,8 +15,8 @@ layout: docs-header
             <a class="Docs-nav-link Docs-nav-link--mobile{% if page.sidebar == link.active %} is-active{% endif %}" href="{{link.hrefMobile | escape}}">
               {{link.title | escape}}
             </a>
-            {% if link.flair %}
-              <div class="Docs-nav-link-flair">{{link.flair | escape}}</div>
+            {% if link.pilltag %}
+              <span class="pill-tag pill-tag--small pill-tag--right">{{link.pilltag | escape}}</span>
             {% endif %}
           </li>
         {% endfor %}
@@ -28,7 +28,7 @@ layout: docs-header
   </header>
 
   <div class="Docs-body">
-    <aside class="Docs-sidebar  Docs-sidebar--defaultLayout">
+    <aside class="Docs-sidebar Docs-sidebar--defaultLayout">
       <nav class="Docs-subnav">
         <dl class="js-accordion Docs-subnav-list" data-accordion-prefix-classes="Docs-subnav">
         {% for section in site.data.docs.sidebar[page.sidebar] %}
@@ -46,7 +46,10 @@ layout: docs-header
           {% endif %}
 
           <dt class="js-accordion__header Docs-subnav-title" data-accordion-opened="true">
-              {{ section.title | escape }}
+            {{ section.title | escape }}
+            {% if section.pilltag %}
+              <span class="pill-tag pill-tag--small pill-tag--right">{{section.pilltag | escape}}</span>
+            {% endif %}
               {% svg assets/svg/carrot-down.svg %}
           </dt>
           <dd class="js-accordion__panel Docs-subnav-section">
@@ -56,6 +59,9 @@ layout: docs-header
                   <li class="js-accordion Docs-subnav-section-list-item Docs-subnav-subsection" data-accordion-prefix-classes="Docs-subnav">
                     <dt class="js-accordion__header Docs-subnav-title" data-accordion-opened="false">
                       {{ page.title | escape }}
+                      {% if page.pilltag %}
+                        <span class="pill-tag pill-tag--small pill-tag--right">{{page.pilltag | escape}}</span>
+                      {% endif %}
                       {% svg assets/svg/carrot-down.svg %}
                     </dt>
                     <dd class="js-accordion__panel Docs-subnav-section Docs-subnav-subsection">
@@ -64,6 +70,9 @@ layout: docs-header
                         <li class="Docs-subnav-section-list-item">
                           <a class="Docs-subnav-link{% if page_href == subpage.href %} is-active{% endif %}" href="/{{subpage.href | escape}}" onclick="highlightSubnav(this.href)">
                             {{ subpage.title | escape }}
+                            {% if subpage.pilltag %}
+                              <span class="pill-tag pill-tag--small">{{subpage.pilltag | escape}}</span>
+                            {% endif %}
                           </a>
                         </li>
                       {% endfor %}
@@ -73,6 +82,9 @@ layout: docs-header
                   <li class="Docs-subnav-section-list-item">
                     <a class="Docs-subnav-link{% if page_href == page.href %} is-active{% endif %}" href="/{{page.href | escape}}" onclick="highlightSubnav(this.href)">
                       {{ page.title | escape }}
+                      {% if page.pilltag %}
+                        <span class="pill-tag pill-tag--small pill-tag--right">{{page.pilltag | escape}}</span>
+                      {% endif %}
                     </a>
                   </li>
                 {% endif %}
@@ -86,7 +98,12 @@ layout: docs-header
   
     <article class="Docs-content">
       <div class="Docs-content-title">
-        <h1>{{ page.title | escape }}</h1>
+        <h1>
+          {% if page.pilltag %}
+            <span class="pill-tag pill-tag--left">{{page.pilltag | escape}}</span>
+          {% endif %}
+          <span>{{ page.title | escape }}</span>
+        </h1>
         {% if page.subtitle %}
         <h2>{{ page.subtitle | escape }}</h2>
         {% endif %}

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -106,7 +106,7 @@ $sidebar-maximum-width: 400px;
 }
 
 .Docs-nav-list-item {
-  // To align the "flair":
+  // To align the "pilltag":
   display: flex;
   align-items: center;
 
@@ -146,16 +146,6 @@ $sidebar-maximum-width: 400px;
     display: block;
   }
 }
-
-.Docs-nav-link-flair {
-  font-size: 12px;
-  background-color: $tilt2-color-gray-lightest;
-  padding-left: $spacing-unit * 0.2;
-  padding-right: $spacing-unit * 0.2;
-  margin-left: $spacing-unit * 0.25;
-  border-radius: $tilt2-border-radius;
-}
-
 
 // Sidebar Nav - browse docs pages
 // --------------------------------------------------
@@ -197,6 +187,7 @@ $sidebar-maximum-width: 400px;
   svg {
     // The caret shouldn't "steal" the click that triggers expand/collapse:
     pointer-events: none;
+    margin-left: auto;
   }
 }
 
@@ -296,6 +287,9 @@ $sidebar-maximum-width: 400px;
     font-size: 38px;
     line-height: 1.4;
     color: $color-red;
+    // To center any pill-tags next to headings
+    display: flex;
+    align-items: center;
   } 
   h2 {
     font-weight: $tilt2-font-weight-sans-light;
@@ -427,14 +421,31 @@ $sidebar-maximum-width: 400px;
 }
 
 .pill-tag {
-  text-transform: uppercase;
-  font-size: $tilt2-font-size-body-small;
-  padding: 5px;
   background-color: $color-off-white;
+  border: 1px solid $tilt2-color-gray-lightest;
   border-radius: $tilt2-border-radius-large * 2;
   color: $tilt2-color-gray-dark;
-  border: 1px solid $tilt2-color-gray-lightest;
   font-family: $tilt2-font-mono;
+  font-size: $tilt2-font-size-body-small;
+  font-weight: $body-font-weight;
+  padding: 5px;
+  text-transform: uppercase;
+}
+
+.pill-tag.pill-tag--small {
+  font-size: 12px;
+}
+
+.pill-tag.pill-tag--bold {
+  font-weight: $tilt2-font-weight-mono-bold;
+}
+
+.pill-tag.pill-tag--right {
+  margin-left: $spacing-unit * 0.20;
+}
+
+.pill-tag.pill-tag--left{
+  margin-right: $spacing-unit * 0.20;
 }
 
 // Page Elements


### PR DESCRIPTION
This PR adds support for adding a `pilltag` to a doc menu item and page heading. The only tag that's actually added to the live docs is the `beta` tag for the Disable Resources docs. I've removed the `new` tag next to the "Tilt API" header link.

Here are a couple screenshots of what that looks like with tags added to more places:

![Screen Shot 2022-01-13 at 4 19 03 PM](https://user-images.githubusercontent.com/23283986/149412465-05786bf2-efcb-4951-a84f-7706301e9601.png)

![Screen Shot 2022-01-13 at 4 24 11 PM](https://user-images.githubusercontent.com/23283986/149412456-581dddbe-b3da-430c-9016-d67d21074757.png)