### PR TITLE
docs: add snippets link/banner to Tiltfile API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,9 @@ sidebar: reference
 
 Tiltfiles are written in _Starlark_, a dialect of Python. For more information on Starlark's built-ins, [see the **Starlark Spec**](https://github.com/bazelbuild/starlark/blob/master/spec.md). The rest of this page details Tiltfile-specific functionality.
 
+> 👀 **Looking for Examples?**
+> Check out our new [Tiltfile Snippets](/snippets.html)!
+
 ## Functions
 
 <ul>

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -1,7 +1,7 @@
 ---
 title: Tiltfile Snippets
 layout: docs
-sidebar: guides
+sidebar: gettingstarted
 hideHelpfulForm: true
 ---
 

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -49,6 +49,7 @@ sidebar:
       href: upgrade.html
     - title: Tiltfile Snippets
       href: snippets.html
+      pilltag: new
 
   - title:  How Does Tilt Work?
     items:

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -47,6 +47,8 @@ sidebar:
       href: install.html
     - title: Upgrade
       href: upgrade.html
+    - title: Tiltfile Snippets
+      href: snippets.html
 
   - title:  How Does Tilt Work?
     items:


### PR DESCRIPTION
Encourage users looking at Tiltfile API to look at the snippets
page.

<img width="1248" alt="Screenshot of Tiltfile API page showing new snippets banner" src="https://user-images.githubusercontent.com/841263/151011018-8543a210-f5a0-43cd-9463-82c24c8b62bb.png">