### PR TITLE
docs: add titles to snippet reference links

### DIFF
--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -21,18 +21,19 @@ hideHelpfulForm: true
       </div>
       <a class="Docs-snippets-item-permalink" href="#snip_{{name}}">Permalink</a>
     </header>
-    
-    <!-- <div>stage: {{snippet.release_stage}}</div> -->
 
     {%- highlight python -%}
       {{snippet.code | strip}}
     {%- endhighlight -%}
 
-    <footer class="Docs-snippets-item-footer">
-      {% if snippet.docs_link %}
-        <a href="{{snippet.docs_link}}">Read More…</a>
-      {% endif %}
-    </footer>
+    {% if snippet.link %}
+      <footer class="Docs-snippets-item-footer">
+        <h5>Reference</h5>
+        <a href="{{snippet.link.href}}">
+          {{ snippet.link.title }}
+        </a>
+      </footer>
+    {% endif %}
   </li>
   {% endfor %}
 </ul>

--- a/src/_data/snippets/docker_build_simple.yml
+++ b/src/_data/snippets/docker_build_simple.yml
@@ -8,4 +8,6 @@ tags:
 - docker
 - docker_build
 release_stage: released
-docs_link: "/tiltfile_concepts.html#build"
+link:
+  title: "Tiltfile Concepts: Build Images"
+  href: "/tiltfile_concepts.html#build"

--- a/src/_data/snippets/docker_compose.yml
+++ b/src/_data/snippets/docker_compose.yml
@@ -7,4 +7,6 @@ tags:
 - docker
 - docker_compose
 release_stage: released
-docs_link: "/api.html#api.docker_compose"
+link:
+  title: "API: docker_compose()"
+  href: "/api.html#api.docker_compose"

--- a/src/_data/snippets/docker_compose_override.yml
+++ b/src/_data/snippets/docker_compose_override.yml
@@ -8,4 +8,6 @@ tags:
 - docker
 - docker_compose
 release_stage: released
-docs_link: "/api.html#api.docker_compose"
+link:
+  title: "API: docker_compose()"
+  href: "/api.html#api.docker_compose"

--- a/src/_data/snippets/k8s_build_deployment.yml
+++ b/src/_data/snippets/k8s_build_deployment.yml
@@ -17,4 +17,6 @@ tags:
   - deployment
   - extensions
 release_stage: released
-docs_link: https://github.com/tilt-dev/tilt-extensions/tree/master/deployment
+link:
+  title: "Extension: deployment"
+  href: https://github.com/tilt-dev/tilt-extensions/tree/master/deployment

--- a/src/_data/snippets/k8s_configmap.yml
+++ b/src/_data/snippets/k8s_configmap.yml
@@ -13,4 +13,6 @@ tags:
 - configmap
 - extensions
 release_stage: released
-docs_link: https://github.com/tilt-dev/tilt-extensions/tree/master/configmap
+link:
+  title: "Extension: configmap"
+  href: https://github.com/tilt-dev/tilt-extensions/tree/master/configmap

--- a/src/_data/snippets/k8s_deployment.yml
+++ b/src/_data/snippets/k8s_deployment.yml
@@ -15,4 +15,6 @@ tags:
 - deployment
 - extensions
 release_stage: released
-docs_link: https://github.com/tilt-dev/tilt-extensions/tree/master/deployment
+link:
+  title: "Extension: deployment"
+  href: https://github.com/tilt-dev/tilt-extensions/tree/master/deployment

--- a/src/_data/snippets/k8s_resource_config1.yml
+++ b/src/_data/snippets/k8s_resource_config1.yml
@@ -10,4 +10,6 @@ tags:
 - k8s
 - k8s_resource
 release_stage: released
-docs_link: "/tiltfile_concepts.html#configuring-kubernetes-resources"
+link:
+  title: "Tiltfile Concepts: Configuring K8s Resources"
+  href: "/tiltfile_concepts.html#configuring-kubernetes-resources"

--- a/src/_data/snippets/k8s_resource_config2.yml
+++ b/src/_data/snippets/k8s_resource_config2.yml
@@ -11,4 +11,6 @@ tags:
 - k8s
 - k8s_resource
 release_stage: released
-docs_link: "/tiltfile_concepts.html#configuring-kubernetes-resources"
+link:
+  title: "Tiltfile Concepts: Configuring K8s Resources"
+  href: "/tiltfile_concepts.html#configuring-kubernetes-resources"

--- a/src/_data/snippets/k8s_resource_port_forward.yml
+++ b/src/_data/snippets/k8s_resource_port_forward.yml
@@ -12,4 +12,6 @@ tags:
 - k8s_resource
 - port_forward
 release_stage: released
-docs_link: "/tiltfile_concepts.html#configuring-kubernetes-resources"
+link:
+  title: "Tiltfile Concepts: Configuring K8s Resources"
+  href: "/tiltfile_concepts.html#configuring-kubernetes-resources"

--- a/src/_data/snippets/k8s_secret.yml
+++ b/src/_data/snippets/k8s_secret.yml
@@ -13,4 +13,6 @@ tags:
 - secret
 - extensions
 release_stage: released
-docs_link: https://github.com/tilt-dev/tilt-extensions/tree/master/secret
+link:
+  title: "Extension: secret"
+  href: https://github.com/tilt-dev/tilt-extensions/tree/master/secret

--- a/src/_data/snippets/k8s_yaml_custom.yml
+++ b/src/_data/snippets/k8s_yaml_custom.yml
@@ -9,4 +9,6 @@ tags:
 - k8s_yaml
 - local
 release_stage: released
-docs_link: "/tiltfile_concepts.html#custom-commands"
+link:
+  title: "Tiltfile Concepts: Generated K8s YAML"
+  href: "/tiltfile_concepts.html#custom-commands"

--- a/src/_data/snippets/k8s_yaml_helm.yml
+++ b/src/_data/snippets/k8s_yaml_helm.yml
@@ -8,4 +8,6 @@ tags:
 - k8s_yaml
 - helm
 release_stage: released
-docs_link: "/tiltfile_concepts.html#deploy"
+link:
+  title: "Tiltfile Concepts: Deploy"
+  href: "/tiltfile_concepts.html#deploy"

--- a/src/_data/snippets/k8s_yaml_kustomize.yml
+++ b/src/_data/snippets/k8s_yaml_kustomize.yml
@@ -8,4 +8,6 @@ tags:
 - k8s_yaml
 - kustomize
 release_stage: released
-docs_link: "/tiltfile_concepts.html#deploy"
+link:
+  title: "Tiltfile Concepts: Deploy"
+  href: "/tiltfile_concepts.html#deploy"

--- a/src/_data/snippets/k8s_yaml_simple.yml
+++ b/src/_data/snippets/k8s_yaml_simple.yml
@@ -11,4 +11,6 @@ tags:
 - k8s
 - k8s_yaml
 release_stage: released
-docs_link: "/tiltfile_concepts.html#deploy"
+link:
+  title: "Tiltfile Concepts: Deploy"
+  href: "/tiltfile_concepts.html#deploy"

--- a/src/_data/snippets/local_go_server.yml
+++ b/src/_data/snippets/local_go_server.yml
@@ -12,4 +12,6 @@ tags:
 - go
 - local_resource
 release_stage: released
-docs_link: "/local_resource.html#serve_cmd"
+link:
+  title: "Local Resource: serve_cmd"
+  href: "/local_resource.html#serve_cmd"

--- a/src/_data/snippets/local_kube_logs.yml
+++ b/src/_data/snippets/local_kube_logs.yml
@@ -9,4 +9,6 @@ tags:
 - k8s
 - local_resource
 release_stage: released
-docs_link: "/local_resource.html#serve_cmd"
+link:
+  title: "Local Resource: serve_cmd"
+  href: "/local_resource.html#serve_cmd"

--- a/src/_data/snippets/local_make.yml
+++ b/src/_data/snippets/local_make.yml
@@ -14,4 +14,6 @@ tags:
 - make
 - local_resource
 release_stage: released
-docs_link: "/local_resource.html"
+link:
+  title: "Local Resource"
+  href: "/local_resource.html"

--- a/src/_data/snippets/local_nodejs_server.yml
+++ b/src/_data/snippets/local_nodejs_server.yml
@@ -12,3 +12,6 @@ tags:
 - nodejs
 - local_resource
 release_stage: released
+link:
+  title: "Local Resource: serve_cmd"
+  href: "/local_resource.html#serve_cmd"

--- a/src/_data/snippets/local_yarn.yml
+++ b/src/_data/snippets/local_yarn.yml
@@ -7,4 +7,6 @@ tags:
 - yarn
 - local_resource
 release_stage: released
-docs_link: "/local_resource.html"
+link:
+  title: "Local Resource"
+  href: "/local_resource.html"

--- a/src/_data/snippets/min_k8s_version.yml
+++ b/src/_data/snippets/min_k8s_version.yml
@@ -10,4 +10,6 @@ tags:
 - k8s
 - tiltfile
 release_stage: released
-docs_link: "https://github.com/tilt-dev/tilt-extensions/tree/master/min_k8s_version"
+link:
+  title: "Extension: min_k8s_version"
+  href: "https://github.com/tilt-dev/tilt-extensions/tree/master/min_k8s_version"

--- a/src/_data/snippets/min_tilt_version.yml
+++ b/src/_data/snippets/min_tilt_version.yml
@@ -8,4 +8,6 @@ code: |
 tags:
 - tiltfile
 release_stage: released
-docs_link: "https://github.com/tilt-dev/tilt-extensions/tree/master/min_tilt_version"
+link:
+  title: "Extension: min_tilt_version"
+  href: "https://github.com/tilt-dev/tilt-extensions/tree/master/min_tilt_version"

--- a/src/_data/snippets/require_local_tool.yml
+++ b/src/_data/snippets/require_local_tool.yml
@@ -26,3 +26,6 @@ code: |
 tags:
 - tiltfile
 release_stage: released
+link:
+  title: "Local Resource"
+  href: "/local_resource.html"

--- a/src/_data/snippets/socat.yml
+++ b/src/_data/snippets/socat.yml
@@ -11,4 +11,6 @@ code: |
 tags:
 - local_resource
 release_stage: released
-docs_link: /api.html#api.local_resource
+link:
+  title: "Local Resource"
+  href: "/local_resource.html"

--- a/src/_data/snippets/update_control_full_manual.yml
+++ b/src/_data/snippets/update_control_full_manual.yml
@@ -15,4 +15,6 @@ tags:
 - local_resource
 - docker_compose
 release_stage: released
-docs_link: "/manual_update_control.html"
+link:
+  title: "Manual Update Control"
+  href: "/manual_update_control.html"

--- a/src/_data/snippets/update_control_ignore_changes.yml
+++ b/src/_data/snippets/update_control_ignore_changes.yml
@@ -15,4 +15,6 @@ tags:
 - local_resource
 - docker_compose
 release_stage: released
-docs_link: "/manual_update_control.html"
+link:
+  title: "Manual Update Control"
+  href: "/manual_update_control.html"

--- a/src/_data/snippets/update_control_only_changes.yml
+++ b/src/_data/snippets/update_control_only_changes.yml
@@ -18,4 +18,6 @@ tags:
 - local_resource
 - docker_compose
 release_stage: released
-docs_link: "/manual_update_control.html"
+link:
+  title: "Manual Update Control"
+  href: "/manual_update_control.html"

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -595,6 +595,11 @@ a.attached-above:before {
   padding-left: $spacing-unit * 0.75;
   padding-right: $spacing-unit * 0.75;
   padding-bottom: $spacing-unit * 0.5;
+
+  h5 {
+    font-variant: small-caps;
+    color: $tilt2-color-gray;
+  }
 }
 
 .Docs-snippets-item-title {


### PR DESCRIPTION
Change the YAML structure so links have both a title and href:
```
link:
  title: "foo"
  href: "/foo.html#bar"
```

Each snippet now shows a "References" footer with the link.

### With Reference Link
<img width="921" alt="Screenshot of snippet with references footer including link" src="https://user-images.githubusercontent.com/841263/151011798-719af5ce-d753-47af-bd61-53a5c9d3cde1.png">

### Without Reference Link
<img width="914" alt="Screenshot of snippet without references footer" src="https://user-images.githubusercontent.com/841263/151011680-493477f8-0494-4355-a2eb-95a8f19147a7.png">

