### PR TITLE
add readme for contributing snippets

### DIFF
--- a/contributing-snippets.md
+++ b/contributing-snippets.md
@@ -18,4 +18,4 @@ contributor: Your Github Handle (optional)
 3. Commit your changes and submit a Pull Request
 
 4. A member of the Tilt team will review your snippet and modify it if necessary.  
-We might decide to not include it in our library. If that's the case, you will receive an explanation.
+If there's a reason that we don't think it's right for our Snippets Library, we'll let you know why. We appreciate you taking the time to contribute!

--- a/contributing-snippets.md
+++ b/contributing-snippets.md
@@ -1,0 +1,19 @@
+Do you have a suggestion for a Tiltfile snippet?
+Submitting a snippet is as straightfoward as submitting a Pull Request.
+
+0. Clone this repository
+
+1. Create a file in src/_data/snippets/*snippet-name*.yml
+
+2. Copy the following content and modify as applicable
+```
+title: Descriptive Name of Your Snippet
+description: Explain what your snippet does
+code: |
+  *Your Snippet Goes Here*
+contributor: Your Github Handle (optional)
+```
+
+3. Commit your snippet and [submit a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
+
+4. A member of the Tilt team will review your snippet and modify it if necessary. We might decide to not include it in our library. If that's the case, you will receive an explanation. 

--- a/contributing-snippets.md
+++ b/contributing-snippets.md
@@ -1,4 +1,5 @@
-Do you have a suggestion for a Tiltfile snippet?
+# Contributing to Tiltfile Snippets
+Would you like to help improve our Snippet Library?  
 Submitting a snippet is as straightfoward as submitting a Pull Request.
 
 0. Clone this repository
@@ -10,10 +11,11 @@ Submitting a snippet is as straightfoward as submitting a Pull Request.
 title: Descriptive Name of Your Snippet
 description: Explain what your snippet does
 code: |
-  *Your Snippet Goes Here*
+  *Your code goes here*
 contributor: Your Github Handle (optional)
 ```
 
-3. Commit your snippet and [submit a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
+3. Commit your changes and submit a Pull Request
 
-4. A member of the Tilt team will review your snippet and modify it if necessary. We might decide to not include it in our library. If that's the case, you will receive an explanation. 
+4. A member of the Tilt team will review your snippet and modify it if necessary.  
+We might decide to not include it in our library. If that's the case, you will receive an explanation.

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -19,6 +19,9 @@ hideHelpfulForm: true
   <li id="snip_{{name}}" class="Docs-snippets-item" data-codeblock="snip_{{name}}">
     <header class="Docs-snippets-item-header">
       <div>
+        {% if snippet.contributor %}
+        <p class="Docs-snippets-item-contributor">✉️ submitted by <a href="https://github.com/{{snippet.contributor}}">{{snippet.contributor}}</a></p>
+        {% endif %}
         <h3 class="Docs-snippets-item-title">{{snippet.title}}</h3>
         <p class="Docs-snippets-item-description">{{snippet.description}}</p>
       </div>

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -5,6 +5,9 @@ sidebar: guides
 hideHelpfulForm: true
 ---
 
+> **Want to contribute?**  
+> Follow [this guide](https://github.com/tilt-dev/tilt.build#contributing-snippets) to find out how to your own snippets!
+
 <ul class="Docs-snippets-list">
   {% assign snippets = site.data.snippets %}
   {% assign keys = snippets | keys %}

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -17,31 +17,33 @@ hideHelpfulForm: true
   {% for name in allkeys %}
   {% assign snippet = snippets[name] %}
   <li id="snip_{{name}}" class="Docs-snippets-item" data-codeblock="snip_{{name}}">
-    <header class="Docs-snippets-item-header">
-      <div>
-        {% if snippet.contributor %}
-        <div class="Docs-snippets-item-contributor">✉️ submitted by <a href="https://github.com/{{snippet.contributor}}">{{snippet.contributor}}</a></div>
-        {% endif %}
-        <a class="Docs-snippets-item-permalink" href="#snip_{{name}}">Permalink</a>
-      </div>
-      <div>
-        <h3 class="Docs-snippets-item-title">{{snippet.title}}</h3>
-        <p class="Docs-snippets-item-description">{{snippet.description}}</p>
-      </div>
-    </header>
+    <div class="Docs-snippets-content">
+      <header class="Docs-snippets-item-header">
+        <div>
+          {% if snippet.contributor %}
+          <div class="Docs-snippets-item-contributor">✉️ submitted by <a href="https://github.com/{{snippet.contributor}}">{{snippet.contributor}}</a></div>
+          {% endif %}
+          <a class="Docs-snippets-item-permalink" href="#snip_{{name}}">Permalink</a>
+        </div>
+        <div>
+          <h3 class="Docs-snippets-item-title">{{snippet.title}}</h3>
+          <p class="Docs-snippets-item-description">{{snippet.description}}</p>
+        </div>
+      </header>
 
-    {%- highlight python -%}
-      {{snippet.code | strip}}
-    {%- endhighlight -%}
+      {%- highlight python -%}
+        {{snippet.code | strip}}
+      {%- endhighlight -%}
 
-    {% if snippet.link %}
-      <footer class="Docs-snippets-item-footer">
-        <h5>Reference</h5>
-        <a href="{{snippet.link.href}}">
-          {{ snippet.link.title }}
-        </a>
-      </footer>
-    {% endif %}
+      {% if snippet.link %}
+        <footer class="Docs-snippets-item-footer">
+          <h5>Reference</h5>
+          <a href="{{snippet.link.href}}">
+            {{ snippet.link.title }}
+          </a>
+        </footer>
+      {% endif %}
+    </div>
   </li>
   {% endfor %}
 </ul>

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -20,12 +20,14 @@ hideHelpfulForm: true
     <header class="Docs-snippets-item-header">
       <div>
         {% if snippet.contributor %}
-        <p class="Docs-snippets-item-contributor">✉️ submitted by <a href="https://github.com/{{snippet.contributor}}">{{snippet.contributor}}</a></p>
+        <div class="Docs-snippets-item-contributor">✉️ submitted by <a href="https://github.com/{{snippet.contributor}}">{{snippet.contributor}}</a></div>
         {% endif %}
+        <a class="Docs-snippets-item-permalink" href="#snip_{{name}}">Permalink</a>
+      </div>
+      <div>
         <h3 class="Docs-snippets-item-title">{{snippet.title}}</h3>
         <p class="Docs-snippets-item-description">{{snippet.description}}</p>
       </div>
-      <a class="Docs-snippets-item-permalink" href="#snip_{{name}}">Permalink</a>
     </header>
 
     {%- highlight python -%}

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -320,8 +320,7 @@ $sidebar-maximum-width: 400px;
 }
 
 .Docs-content h2 {
-  padding-top: $spacing-unit * 2.25;
-  margin-top: -$spacing-unit * 2.25;
+  scroll-margin-top: $spacing-unit * 2.25;
 
   a:hover:before {
     content: "🔗 ";
@@ -336,11 +335,14 @@ $sidebar-maximum-width: 400px;
   margin-top: $spacing-unit * 0.75;
 }
 
-.Docs-content > h3,
-.Docs-content > h3 a {
-  margin-top: $spacing-unit * 1.5;
-  color: $text-color;
-  text-decoration: none;
+.Docs-content > h3 {
+  scroll-margin-top: $spacing-unit * 2.25;
+
+  a {
+    margin-top: $spacing-unit * 1.5;
+    color: $text-color;
+    text-decoration: none;
+  }
 }
 
 
@@ -569,12 +571,9 @@ a.attached-above:before {
 }
 .Docs-snippets-item {
   list-style: none;
-  padding-top: $spacing-unit * 2.5;
-  margin-top: -$spacing-unit !important; // Override .Docs-content > ul
+  scroll-margin-top: $spacing-unit * 2.5;
   margin-left: 0 !important; // Override .Docs-content > ul li
-}
 
-.Docs-snippets-content {
   border: 2px solid $tilt2-color-gray-lighter;
   border-radius: $spacing-unit * 0.25;
 

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -586,7 +586,6 @@ a.attached-above:before {
   padding-left: $spacing-unit * 0.75;
   padding-right: $spacing-unit * 0.75;
   padding-bottom: 0;
-  display: flex;
   justify-content: space-between;
 }
 
@@ -613,10 +612,15 @@ a.attached-above:before {
 
 .Docs-snippets-item-permalink {
   font-size: $tilt2-font-size-body-small;
+  float: right;
 }
 
 .Docs-snippets-item-contributor {
+  display: inline-block;
+  padding-bottom: $spacing-unit * 0.25;
+  margin-top: 0;
   font-size: $tilt2-font-size-body-small;
+
   a, a:visited {
     color: $color-skyBlue;
   }

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -570,7 +570,7 @@ a.attached-above:before {
 .Docs-snippets-item {
   list-style: none;
   padding-top: $spacing-unit * 2.5;
-  margin-top: -$spacing-unit * 2.5;
+  margin-top: -$spacing-unit !important; // Override .Docs-content > ul
   margin-left: 0 !important; // Override .Docs-content > ul li
 }
 

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -617,4 +617,7 @@ a.attached-above:before {
 
 .Docs-snippets-item-contributor {
   font-size: $tilt2-font-size-body-small;
+  a, a:visited {
+    color: $color-skyBlue;
+  }
 }

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -315,17 +315,21 @@ $sidebar-maximum-width: 400px;
 .Docs-content > h2 a {
   font-weight: $tilt2-font-weight-sans-bold;
   font-size: 28px;
-  margin-top: $spacing-unit * 1.75;
   color: $color-blue;
   text-decoration: none;
 }
 
-.Docs-content h2 a:hover:before {
-  content: "🔗 ";
-  position: absolute;
-  margin-left: -$spacing-unit;
-  margin-top: 4px; // Visually center
-  font-size: 80%;
+.Docs-content h2 {
+  padding-top: $spacing-unit * 2.25;
+  margin-top: -$spacing-unit * 2.25;
+
+  a:hover:before {
+    content: "🔗 ";
+    position: absolute;
+    margin-left: -$spacing-unit;
+    margin-top: 4px; // Visually center
+    font-size: 80%;
+  }
 }
 
 .Docs-content > h2 + h3 {

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -567,10 +567,14 @@ a.attached-above:before {
 .Docs-snippets-list {
   margin-top: $spacing-unit * 2 !important; // Override .Docs-content > ul
 }
-
 .Docs-snippets-item {
   list-style: none;
+  padding-top: $spacing-unit * 2.5;
+  margin-top: -$spacing-unit * 2.5;
   margin-left: 0 !important; // Override .Docs-content > ul li
+}
+
+.Docs-snippets-content {
   border: 2px solid $tilt2-color-gray-lighter;
   border-radius: $spacing-unit * 0.25;
 

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -614,3 +614,7 @@ a.attached-above:before {
 .Docs-snippets-item-permalink {
   font-size: $tilt2-font-size-body-small;
 }
+
+.Docs-snippets-item-contributor {
+  font-size: $tilt2-font-size-body-small;
+}

--- a/src/_sass/utility.scss
+++ b/src/_sass/utility.scss
@@ -283,6 +283,7 @@
 .copy-to-clipboard {
   display: block;
   margin: -($spacing-unit / 2) 0 ($spacing-unit / 8) auto;
+  margin-right: $spacing-unit * 0.5;
 
   font-family: $chrome-font-family;
   color: $color-red;


### PR DESCRIPTION
Hi @hyu @SurbhiSGupta @nicksieger,

could you please review the following changes:
- adds a Readme, explaining how to contribute a snippet
- reference Readme in snippet library
- fixed styling, so the top content is not hidden behind header when navigating to anchor links
- moved copy-to-clipboard button away from right edge

I specifically did not include `tags` and `release_stage` in the template, since they are currently only for internal usage.

@SurbhiSGupta I also included an example design for adding a contributor's handle to a snippet. I'm 0% committed to the design, though. Interested to hear your suggestions!
<img width="988" alt="Screenshot 2022-01-26 at 21 19 42" src="https://user-images.githubusercontent.com/2743542/151241793-a01a516b-1ad5-4a43-8c5b-fedf33dd073a.png">

