### PR TITLE
docs: docs on the first argument of docker_build

### DIFF
--- a/docs/dependent_images.md
+++ b/docs/dependent_images.md
@@ -28,7 +28,7 @@ docker_build('my-image', '.')
 
 `.` is still the directory of files you're including. Tilt will automatically watch them for changes.
 
-`my-image` is an image selector. Tilt will scan all your deployment YAML for
+`my-image` is an image selector. Tilt will scan all your workload manifests for
 images, and match any object that contains the image name `my-image` (regardless
 of tag).
 

--- a/docs/dependent_images.md
+++ b/docs/dependent_images.md
@@ -69,7 +69,7 @@ check out our [custom resource guide](custom_resource.html).
 When you start adding multiple services to your app, it's easiest
 to just copy a new Dockerfile for each service and tweak a few parameters.
 
-Once you have a few services, you may that duplication can start to feel messy.
+Once you have a few services, you may find that duplication can start to feel messy.
 Sometimes you update one Dockerfile but forget to update the others.
 Building all the services is slow.
 

--- a/docs/dependent_images.md
+++ b/docs/dependent_images.md
@@ -32,7 +32,7 @@ docker_build('my-image', '.')
 images, and match any object that contains the image name `my-image` (regardless
 of tag).
 
-This creates a dependency between your deploy YAML and `my-image`. Every time 
+This creates a dependency between your workload and `my-image`. Every time 
 the image rebuilds, Tilt knows it may need to restart your containers.
 
 - If the image hasn't changed, the containers won't restart.

--- a/docs/dependent_images.md
+++ b/docs/dependent_images.md
@@ -1,23 +1,84 @@
 ---
-title: Building on a Base Image
-description: "With multiple services in your app, a common pattern is to create a common base image with common dependencies"
+title: Getting Started with Image Builds
+description: "How to go from building one image to building multiple images"
 layout: docs
 sidebar: guides
 ---
 
+This is a brief intro to automatically build and deploy images
+to a local dev environment.
+
+We'll start with a single image.
+
+## Going from `docker build` to `docker_build`
+
+On the command-line, an image build looks like this:
+
+```shell
+docker build -t my-image .
+```
+
+`my-image` is the image name. `.` is the directory of files that you're including in the image.
+
+To make this part of your dev environment, add this to your Tiltfile:
+
+```python
+docker_build('my-image', '.')
+```
+
+`.` is still the directory of files you're including. Tilt will automatically watch them for changes.
+
+`my-image` is an image selector. Tilt will scan all your deployment YAML for
+images, and match any object that contains the image name `my-image` (regardless
+of tag).
+
+This creates a dependency between your deploy YAML and `my-image`. Every time 
+the image rebuilds, Tilt knows it may need to restart your containers.
+
+- If the image hasn't changed, the containers won't restart.
+
+- If the image has changed, the containers should always restart with a fresh image.
+
+(Note that this is different than what usually happens in prod, where you want
+more control over the gradual rollout of a new image. Tilt has some tricks to
+make this work well in dev. The implementation details are discussed a bit in
+[our custom_build guide](custom_build.html).)
+
+### Advanced Image Matching
+
+`my-image` is a matcher that ignores tags.
+
+Some teams have one mega image with all their services, and use tags to
+denote which service to run.
+
+```python
+docker_build('my-mega-image:service-a', '.', entrypoint='/service-a')
+docker_build('my-mega-image:service-b', '.', entrypoint='/service-b')
+```
+
+If you specify a tag, Tilt will only match deploy objects with that exact tag in
+their image name.
+
+If you're trying to inject images into [Custom
+Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+(in other words, if you're not using built-in Kubernetes objects like Deployment and Job),
+check out our [custom resource guide](custom_resource.html).
+
+## Multiple Images
+
 When you start adding multiple services to your app, it's easiest
 to just copy a new Dockerfile for each service and tweak a few parameters.
 
-Once you have a few services, that duplication can start to feel messy.
+Once you have a few services, you may that duplication can start to feel messy.
 Sometimes you update one Dockerfile but forget to update the others.
 Building all the services is slow.
 
 A common pattern is to create a common base image with the dependencies for
 multiple services.
 
-With Tilt, you can describe when to re-build each image in the dependency graph.
+So let's set up a dependency tree of `docker_build`s that build on each other.
 
-## Building a `node_modules` Base Image
+### Building a `node_modules` Base Image
 
 Let's look at an example. We want to create a NodeJS server with two Docker images:
 
@@ -124,7 +185,7 @@ Building Dockerfile:
 If you make a change to server.js, Tilt knows it can skip the first image build
 and just do the second.
 
-## Adding Live Updates
+### Adding Live Updates
 
 Once you've got the two image builds working, you can add a
 live update rule to sync files into your app. This is much faster
@@ -159,10 +220,10 @@ never the base image. Tilt's live update system matches the image in the contain
 so needs to be attached to the deployed image to figure out which container
 to update.
 
-## Try it Yourself
+## Example Code
 
-All the source code for this example is [on
-GitHub](https://github.com/tilt-dev/tilt-example-base-image).
+- An example of a base image for package.json dependencies: [tilt-example-base-image](https://github.com/tilt-dev/tilt-example-base-image)
 
-Try running it yourself with Tilt. Make changes to both `package.json` and `server.js`
-and see how Tilt rebuilds only what has changed.
+- An integration test that uses 2 levels of base images: [live_update_base_image](https://github.com/tilt-dev/tilt/blob/master/integration/live_update_base_image/Tiltfile)
+
+- An integration test that uses tag-based image matching: [imagetags](https://github.com/tilt-dev/tilt/blob/master/integration/imagetags/Tiltfile)

--- a/docs/personal_registry.md
+++ b/docs/personal_registry.md
@@ -66,6 +66,25 @@ Some managed Kubernetes services have their own credential helpers:
 These will ensure that your login credentials for kubectl and your login
 credentials for the registry stay in-sync.
 
+### What to Put in `docker_build`
+
+The first argument to `docker_build` is an image _selector_.
+
+```
+docker_build('my-image', '.)
+```
+
+`my-image` will match against any images in your deploy YAML (e.g., your Kubernetes Deployment).
+
+If you're using a local cluster, don't worry what the host of the image name is!
+The main rule is that it needs to match the image name in the YAML. Tilt will
+automatically inject the fully-qualified image name for the local registry into
+your deploy YAML.
+
+If you're using a remote cluster, you should use the registry name in both the
+`docker_build` and in your YAML.  For example, GKE registries look like
+`gcr.io/my-project/my-image-name'.
+
 ## The Medium-Easy Way (for 4% of users)
 
 If you're using a cluster that doesn't have a registry,
@@ -88,6 +107,9 @@ the ephemeral registry, and pull it into your cluster.
 `ttl.sh` is encrypted over HTTPS but not authenticated. It will delete your
 image after an hour. So it's a good option if you're trying out a sample
 project (like one of the Tilt examples).
+
+If you use `default_registry`, there's no need to have the registry host in
+`docker_build()` or in your deploy YAML.
 
 ## The Medium Way (for 1% of users)
 

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -111,7 +111,7 @@ sidebar:
 
     - title: Building Images
       items:
-        - title: Overview
+        - title: Getting Started with Image Builds
           href: dependent_images.html
         - title: Setting up any Image Registry
           href: personal_registry.html


### PR DESCRIPTION
Hello @nicksieger, @lizzthabet,

Please review the following commits I made in branch nicks/build:

e6b6220e8c89ec30ea9105a5de0ace158d39e632 (2022-02-01 11:04:57 -0500)
docs: docs on the first argument of docker_build
- Reframe the image-building doc with a more gentle intro to building a single image

- Add some notes to the registry doc about whether docker_build() should contain the registry name

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics