### PR TITLE
snippets: fix copy-to-clipboard GA event

### DIFF
--- a/src/assets/js/copy-code.js
+++ b/src/assets/js/copy-code.js
@@ -51,8 +51,8 @@
             // element
             const analyticsEl = e.trigger.closest('[data-codeblock]')
             if (gtag && analyticsEl && analyticsEl.dataset.codeblock) {
-                gtag('event', 'copy-to-clipboard', {
-                    'codeblock': analyticsEl.dataset.codeblock
+                gtag('event', analyticsEl.dataset.codeblock, {
+                    'event_category': 'copy-to-clipboard'
                 });
             }
         });


### PR DESCRIPTION
Turns out I don't know how to `gtag` 🤦 

The category will now be `copy-to-clipboard` and each event _action_ in that category will be the name of a codeblock that was copied. Currently, these are under the `general` category with an _action_ of `copy-to-clipboard` but the codeblock wasn't actually propagated because you can't send arbitrary data pairs with events in GA - `event_category` is "special" 🙃 