### PR TITLE
docs: rewrite the extensions guide

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -159,7 +159,7 @@ Notice that in the above, we define `hello_world` to pull its source from
 
 ## Debugging Extension Loading with the CLI
 
-A Tilt sessions publishes the names of all repos and extensions it's using and where they live on disk.
+A Tilt session publishes the names of all repos and extensions it's using and where they live on disk.
 
 You can read this info with the CLI. Here are some common commands you might use
 to explore the status. (We use `jq` to prettify the JSON.)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -17,7 +17,7 @@ But we also see dev rules that are particular to a team like:
 
 - Custom buttons for operations like resetting a dev database or upgrading a dependency.
 
-And you want to share those snippets across repos or even between across companies!
+And you want to share those snippets across repos or even across companies!
 
 That's why Tilt has an extension system for writing and sharing snippets of
 Tiltfile functionality!

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,40 +1,196 @@
 ---
 title: Extensions
-description: "Extensions are open-source packaged functions that extend the capability Tilt, right inside your Tiltfile."
+description: "Packaged functions that add new functionality to your dev env."
 layout: docs
 sidebar: guides
 ---
 
-Extensions (available starting in v0.12.11, see [releases](https://github.com/tilt-dev/tilt/releases)) are open-source packaged functions that extend the capability Tilt, right inside your Tiltfile.
+Tilt lets you define your dev environment with a Tiltfile.
 
-We've seen the Tilt community actively share code snippets of Tiltfile functionality in [Slack #tilt](https://kubernetes.slack.com/messages/CESBL84MV/), including ideas such as forcing resources into different namespaces, injecting sidecars, and even running tests. We've created the Extensions platform to streamline this effort, especially helping Tilt newcomers leverage ideas from existing users. Consider [contributing an extension](contribute_extension.html).
+We have many built-in APIs for defining local tasks, image builds, and containerized servers.
 
-## Published extensions
-The [tilt-extensions repo](https://github.com/tilt-dev/tilt-extensions) lists all published extensions.
+But we also see dev rules that are particular to a team like:
 
-## Use an extension
-Suppose we want to use the [`hello_world` extension](https://github.com/tilt-dev/tilt-extensions/tree/master/hello_world), which prints "Hello world!". First, [`load()`](api.html#api.load) the extension with a special `ext://` syntax, referring to both the extension name `hello_world`, and function name `hi`,  in your Tiltfile:
+- Checks that the right versions of local tools are installed.
+
+- Scripts for defining image builds or deploys.
+
+- Custom buttons for operations like resetting a dev database or upgrading a dependency.
+
+And you want to share those snippets across repos or even between across companies!
+
+That's why Tilt has an extension system for writing and sharing snippets of
+Tiltfile functionality!
+
+## Using an extension: "Hello world!"
+
+As an easy introduction, let's look at the `hello_world` extension.
+
+The source code for this extension is
+[here](https://github.com/tilt-dev/tilt-extensions/blob/master/hello_world/Tiltfile)
+and has exactly two (2) lines of code:
+
+```python
+def hi():
+  print("Hello world!")
+```
+
+It exports one function, `hi`, that simply prints "Hello world!".
+
+Let's load this extension into our project:
+
+```python
+load('ext://hello_world', 'hi')
+hi()
+```
+
+When you run `tilt ci` in this project, you'll see output like:
+
+```shell
+Initial Build • (Tiltfile)
+Loading Tiltfile at: /home/nick/src/scratch/Tiltfile
+Hello world!
+Successfully loaded Tiltfile (1.990905ms)
+ERROR: No resources found. Check out https://docs.tilt.dev/tutorial.html to get started!
+```
+
+Tilt printed the message! Tilt also printed an error because it doesn't make any sense
+to have a dev environment that only prints "Hello world!". 🙃
+
+## Discovering extensions
+
+The [tilt-extensions repo](https://github.com/tilt-dev/tilt-extensions) contains
+many general-purpose extensions from the Tilt community.
 
 ```python
 load('ext://hello_world', 'hi')
 ```
 
-Now when you call `hi()` in your Tiltfile, Tilt will print "Hello world!".
+The `load()` call above is loading the extension from the `tilt-extensions` repo!
 
-## Behind the scenes
-Tilt resolves `ext://hello_world` to [tilt-extensions/blob/master/hello_world/Tiltfile](https://github.com/tilt-dev/tilt-extensions/blob/master/hello_world/Tiltfile). So when the extension is first loaded into your project, Tilt copies the remote Tiltfile into the `tilt_modules` directory of your local project. I.e. Tilt writes the contents of `ext://hello_world` into `tilt_modules/hello_world`.
+In particular,
 
-## Commit to source control
-Commit the `tilt_modules` directory to your project repo (**do not** `gitignore` it), so that your teammates don't have to download it, and to ensure that your entire team uses the same copy of the extension. Once Tilt has downloaded an extension, it will not be updated, avoiding suprise breakages.
+- The `tilt-extensions` repo gets checked out in the background.
 
-Tilt doesn't support versioning of extensions at the moment.
+- Tilt reads the Tiltfile under `hello_world/Tiltfile`
 
-(To get notified about versioning, please subscribe to [this issue](https://github.com/tilt-dev/tilt/issues/3426)
-and thumbs-up it so we know you care about it.)
+- Tilt sets the variable `hi` in the local scope to the `hi` function in the extension.
 
-## Avoid changing extensions
-Avoid changing extensions directly in `tilt_modules`. If you're interested in modifying an extension, consider [contributing a new one](contribute_extension.html) instead,
+## Sharing Tiltfile Code in a Single Repo
 
+If the common Tiltfile code you want to share is in a single repo, you don't need the
+extension system at all!
 
-## Next steps
-[Request new extensions](https://github.com/tilt-dev/tilt/issues) or [contribute a new one](contribute_extension.html).
+The first argument to `load()` can be a relative file path.
+
+```python
+load('./common/Tiltfile', 'hi')
+```
+
+The `load()` function has a nice syntax for binding variables, but that makes
+its API a bit rigid. For more complex scripting, there's a `load_dynamic`
+function.
+
+```python
+symbols = load_dynamic('./common/Tiltfile')
+hi = symbols.get('hi')
+```
+
+For more on `load()` and `load_dynamic()`, see the [API
+reference](https://docs.tilt.dev/api.html#api.load) or our blog post [Load
+Dynamic](https://blog.tilt.dev/2020/11/03/load-dynamic.html).
+
+## Modifying the Default Extensions Locally
+
+In Tilt v0.25, we've made it easy to load the default extension repo locally.
+
+Let's start with the `hello_world` example above:
+
+```python
+load('ext://hello_world', 'hi')
+```
+
+This is a shorthand with nice defaults. You could write it like this:
+
+```python
+v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions', ref='HEAD')
+v1alpha1.extension(name='hello_world', repo_name='default', repo_path='hello_world')
+load('ext://hello_world', 'hi')
+```
+
+These two snippets are equivalent. The second snippet explicitly spells out that
+there's an extension repo called `default` at
+`https://github.com/tilt-dev/tilt-extensions`.  The extension `hello_world`
+gets loaded from the path `hello_world` in the `default` repo.
+
+We could also use a repo on local disk:
+
+```shell
+v1alpha1.extension_repo(name='default', url='file:///usr/nick/src/tilt-extensions')
+load('ext://hello_world', 'hi')
+```
+
+The `file:///` syntax only accepts absolute paths. You would only use it for local
+experimentation. `load()` and `load_dynamic()` are better fits when you want to load
+shared functions from a relative path.
+
+## Managing Your Own Extension Repo
+
+The `extension_repo` API lets you replace the default repo with your own fork.
+
+For example, you can fork the shared `tilt-extensions` repo, use a `stable` tag 
+to denote the version that most people should use, then add some code to your Tiltfile to pin it:
+
+```python
+v1alpha1.extension_repo(name='default', url='https://github.com/my-org/tilt-extensions', ref='stable')
+load('ext://hello_world', 'hi')
+```
+
+Alternatively, you can add new extension repos alongside the default one.
+
+```python
+v1alpha1.extension_repo(name='my-repo', url='https://github.com/my-org/tilt-extensions', ref='HEAD')
+v1alpha1.extension(name='hello_world', repo_name='my-repo', repo_path='hello_world')
+load('ext://hello_world', 'hi')
+```
+
+Notice that in the above, we define `hello_world` to pull its source from
+`my-repo` rather than `default`.
+
+## Debugging Extension Loading with the CLI
+
+A Tilt sessions publishes the names of all repos and extensions it's using and where they live on disk.
+
+You can read this info with the CLI. Here are some common commands you might use
+to explore the status. (We use `jq` to prettify the JSON.)
+
+```bash
+$ tilt get extensionrepo
+NAME      CREATED AT
+default   2022-02-04T18:56:38Z
+
+$ tilt get extensionrepo default -o jsonpath='{.status}{"\n"}' | jq
+{
+  "checkoutRef": "6f4d3436c557d70bb0810b0da1acb99c364120b6",
+  "lastFetchedAt": "2022-02-04T17:18:44Z",
+  "path": "/home/nick/.local/share/tilt-dev/tilt_modules/github.com/tilt-dev/tilt-extensions"
+}
+
+$ tilt get extension
+NAME          CREATED AT
+hello_world   2022-02-04T18:56:38Z
+
+$ tilt get extension hello_world -o jsonpath='{.status}{"\n"}' | jq
+{
+  "path": "/home/nick/.local/share/tilt-dev/tilt_modules/github.com/tilt-dev/tilt-extensions/hello_world/Tiltfile"
+}
+```
+
+## Sharing Extensions with the Community
+
+If you have an extension that you think would be generally useful, we love to
+see people contribute them!
+
+Check out our [contributing extensions](contribute_extension.html) guide
+for more detail on the pull request and review process.
+


### PR DESCRIPTION
Hello @landism, @nicksieger,

Please review the following commits I made in branch nicks/extensions:

43e170d3ea1424493e697ed8829c371a1e3b984f (2022-02-04 15:53:46 -0500)
docs: rewrite the extensions guide
includes all the changes from https://github.com/tilt-dev/tilt/pull/5445
on new extension download semantics

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics