### PR TITLE
Fix incorrect helm_remote link

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -95,7 +95,7 @@ examples of what you can do with a Tiltfile. Load them into your own Tiltfile. I
 - [`hasura`](https://github.com/tilt-dev/tilt-extensions/tree/master/hasura): Deploys [Hasura GraphQL Engine](https://hasura.io/) and monitors metadata/migrations changes locally.
 - [`hello_world`](https://github.com/tilt-dev/tilt-extensions/tree/master/hello_world): Print "Hello world!". Used in [Extensions](https://docs.tilt.dev/extensions.html).
 - [`helm_remote`](https://github.com/tilt-dev/tilt-extensions/tree/master/helm_remote): Install a remote Helm chart (in a way that gets properly uninstalled when running `tilt down`)
-- [`helm_resource`](/helm_resource): Deploy with the Helm CLI. New Tilt users should prefer this approach over `helm_remote`.
+- [`helm_resource`](https://github.com/tilt-dev/tilt-extensions/tree/master/helm_resource): Deploy with the Helm CLI. New Tilt users should prefer this approach over `helm_remote`.
 - [`honeycomb`](https://github.com/tilt-dev/tilt-extensions/tree/master/honeycomb): Report dev env health metrics to [Honeycomb](https://honeycomb.io).
 - [`jest_test_runner`](https://github.com/tilt-dev/tilt-extensions/tree/master/jest_test_runner): Jest JavaScript test runner. Example from [Contribute an Extension](https://docs.tilt.dev/contribute_extension.html).
 - [`k8s_attach`](https://github.com/tilt-dev/tilt-extensions/tree/master/k8s_attach): Attach to an existing Kubernetes resource that's already in your cluster. View their health and live-update them in-place.


### PR DESCRIPTION
The current link for `helm_resource` in the docs results in a 404. I believe the author wanted to link the extension on GitHub.