### PR TITLE
docs: adds scroll margin to each item in function list

### DIFF
--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -313,6 +313,7 @@ $sidebar-maximum-width: 400px;
 
 .Docs-content > h2,
 .Docs-content > h2 a {
+  scroll-margin-top: $spacing-unit * 2.25;
   font-weight: $tilt2-font-weight-sans-bold;
   font-size: 28px;
   color: $color-blue;
@@ -320,8 +321,6 @@ $sidebar-maximum-width: 400px;
 }
 
 .Docs-content h2 {
-  scroll-margin-top: $spacing-unit * 2.25;
-
   a:hover:before {
     content: "🔗 ";
     position: absolute;

--- a/src/_sass/docs.scss
+++ b/src/_sass/docs.scss
@@ -409,6 +409,9 @@ $sidebar-maximum-width: 400px;
   }
 }
 
+.Docs-content > .function > .sig-object {
+  scroll-margin-top: $spacing-unit * 2.25;
+}
 
 .Docs-footer {
   margin-top: $spacing-unit * 3;


### PR DESCRIPTION
Hi @nicksieger @lizzthabet,

could you please review the following changes:
- added a scroll margin to the top of items in the Tiltfile & CLI section

When you navigate to an item through a permalink (e.g. https://docs.tilt.dev/api.html#api.decode_json) the upper part of the content is hidden behind the header. This PR fixes it.
It's the same issue as https://github.com/tilt-dev/tilt.build/pull/1048/commits/f53f97fe738cd7b33afdb83c00dc1fc9b4d9dcd6