### PR TITLE
docs: rebuild api docs

### DIFF
--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -8306,6 +8306,24 @@ you don&#x2019;t get the nice syntactic sugar of binding local variables.
              </span>
             </span>
            </em>
+           ,
+           <em class="sig-param">
+            <span class="n">
+             <span class="pre">
+              stdin
+             </span>
+            </span>
+            <span class="o">
+             <span class="pre">
+              =
+             </span>
+            </span>
+            <span class="default_value">
+             <span class="pre">
+              None
+             </span>
+            </span>
+           </em>
            <span class="sig-paren">
             )
            </span>
@@ -8516,6 +8534,38 @@ the operating system as program name and args.
                  </span>
                 </code>
                 . Defaults to the Tiltfile&#x2019;s location.
+               </p>
+              </li>
+              <li>
+               <p>
+                <strong>
+                 stdin
+                </strong>
+                (
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Optional
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ]) &#x2013; If not
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  None
+                 </span>
+                </code>
+                , will be written to
+                <code class="docutils literal notranslate">
+                 <span class="pre">
+                  command
+                 </span>
+                </code>
+                &#x2019;s stdin.
                </p>
               </li>
              </ul>


### PR DESCRIPTION
this is just a run of `make api` against head since we didn't have https://github.com/tilt-dev/tilt/pull/5657 on the last release