### PR TITLE
Lian/editor support docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,8 +7,8 @@ sidebar: reference
 
 Tiltfiles are written in _Starlark_, a dialect of Python. For more information on Starlark's built-ins, [see the **Starlark Spec**](https://github.com/bazelbuild/starlark/blob/master/spec.md). The rest of this page details Tiltfile-specific functionality.
 
-> 👀 **Looking for Examples?**
-> Check out our new [Tiltfile Snippets](/snippets.html)!
+> 👀 **Looking for Examples?**  
+> Check out our [Tiltfile Snippets](/snippets.html)!
 
 ## Functions
 

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -4,7 +4,8 @@ layout: docs
 sidebar: gettingstarted
 ---
 
-Whether you're just starting or are a seasoned Tilter, writing Tiltfiles should be fun, not tedious.
+Whether you're just starting or are a seasoned Tilter, writing `Tiltfile`s should be fun, not tedious.  
+Our goal with Tilt is to keep users in their development flow with minimal interruptions, that includes switching context to look up `Tiltfile` documentation.
 
 We're offering Tiltfile support for [VS Code](https://code.visualstudio.com/) and select IDEs of the [JetBrains suite](https://www.jetbrains.com/products/#type=ide).  
 All code is public and open source. We appreciate contributions of all kinds.

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -4,8 +4,8 @@ layout: docs
 sidebar: gettingstarted
 ---
 
-Whether you're just starting or are a seasoned Tilter, writing `Tiltfile`s should be fun, not tedious.  
-Our goal with Tilt is to keep users in their development flow with minimal interruptions, that includes switching context to look up `Tiltfile` documentation.
+Whether you're just starting or are a seasoned Tilter, writing `Tiltfile`s should not be tedious.  
+We want to make it easy to experiment with your Tiltfile, so you can experience the magic of Tilt's responsiveness with minimal interruptions to your development flow, that includes switching context to look up `Tiltfile` documentation.
 
 We're offering Tiltfile support for [VS Code](https://code.visualstudio.com/) and select IDEs of the [JetBrains suite](https://www.jetbrains.com/products/#type=ide).  
 All code is public and open source. We appreciate contributions of all kinds.

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,0 +1,19 @@
+---
+title: Editor Support
+layout: docs
+sidebar: gettingstarted
+---
+
+Whether you're just starting or are a seasoned Tilter, writing Tiltfiles should be fun, not tedious.
+
+We're offering Tiltfile support for [VS Code](https://code.visualstudio.com/) and select IDEs of the [JetBrains suite](https://www.jetbrains.com/products/#type=ide).  
+All code is public and open source. We appreciate contributions of all kinds.
+
+## VS Code
+The [official `Tiltfile` extension](https://marketplace.visualstudio.com/items?itemName=tilt-dev.Tiltfile) is available at the VS Code marketplace.  
+It provides syntax highlighting, autocomplete and signature support for `Tilfile` functions.
+
+![](assets/img/vscode-extension.gif)
+
+## TextMate bundles
+The [tiltfile.tmbundle](https://github.com/tilt-dev/tiltfile.tmbundle) offers syntax highlighting for any IDEs supporting TextMate bundles, like IntelliJ GoLand, PyCharm or WebStorm.

--- a/docs/tiltfile_authoring.md
+++ b/docs/tiltfile_authoring.md
@@ -4,6 +4,10 @@ description: "This tutorial walks you through setting up Tilt for your project."
 layout: docs
 sidebar: guides
 ---
+
+> 🖊️ **Need more direct guidance?**  
+> Check out our new [Editor Support page](./editor.html)
+
 This tutorial walks you through setting up Tilt for your project. 
 
 It should take 15 minutes, and assumes you've already [installed Tilt](install.html). Before you begin, you may want to join the `#tilt` channel in [Kubernetes Slack](http://slack.k8s.io) for technical and moral support.

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -49,6 +49,8 @@ sidebar:
       href: upgrade.html
     - title: Tiltfile Snippets
       href: snippets.html
+    - title: Editor Support
+      href: editor.html
       pilltag: new
 
   - title:  How Does Tilt Work?


### PR DESCRIPTION
Hi @nicksieger, @landism, @hyu,

please review the following changes:
- adds draft for Editor Support Docs
- callout new docs in Tiltfile authoring docs
- modify references to Snippet Library not to be "new" anymore

