### PR TITLE
docs: remove some calendly links that are rarely used

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -4,8 +4,6 @@ load('ext://honeycomb', 'honeycomb_collector')
 if os.environ.get('HONEYCOMB_API_KEY', '') and os.environ.get('HONEYCOMB_DATASET', ''):
   honeycomb_collector()
 
-enable_feature('disable_resources')
-
 default_registry('gcr.io/windmill-public-containers')
 set_team('0584d8f6-05a2-49f5-923b-657afef098fe')
 username = str(local('whoami')).rstrip('\n')
@@ -48,9 +46,9 @@ docker_build('blog-site', '.', dockerfile='deploy/blog.dockerfile',
                                               'blog/Gemfile', 'blog/Gemfile.lock'])
              ])
 
-k8s_resource('tilt-site', port_forwards=[port_forward(4000, name='tilt-site')])
-k8s_resource('docs-site', port_forwards=[port_forward(4001, name='docs-site')], resource_deps=['make-api'])
-k8s_resource('blog-site', port_forwards=[port_forward(4002, name='blog-site')])
+k8s_resource('tilt-site', port_forwards=[port_forward(4000, 4000, name='tilt-site')])
+k8s_resource('docs-site', port_forwards=[port_forward(4001, 4000, name='docs-site')], resource_deps=['make-api'])
+k8s_resource('blog-site', port_forwards=[port_forward(4002, 4000, name='blog-site')])
 
 local_resource(
   name='gem-update',

--- a/docs/debug_faq.md
+++ b/docs/debug_faq.md
@@ -179,4 +179,3 @@ Here are some example scripts that report these spans as:
 - [A statsd reporter](https://github.com/jazzdan/statsd_example/blob/master/main.rb)
 
 This is an experimental feature designed for larger companies.
-If this sounds interesting to you, [**please reach out**](https://calendly.com/nick-at-tilt/30min).

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,8 +2,6 @@
 title: Install
 layout: docs
 description: "Tilt is available for macOS, Linux, and Windows"
-has_calendly: true
-has_calendly_popup: true
 sidebar: gettingstarted
 ---
 

--- a/docs/local_vs_remote.md
+++ b/docs/local_vs_remote.md
@@ -128,9 +128,7 @@ well for their team, including:
   the same files over and over
 
 If you're interested in setting this up, or chatting about potential native
-solutions in Tilt to auto-configure this, please reach out to us.
-
-[**Schedule a Meeting**](https://calendly.com/nick-at-tilt/remote-builds)
+solutions in Tilt to auto-configure this, [please reach out to us](/#community).
 
 ## Local/Remote Networking
 

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -14,9 +14,6 @@
   {% if page.has_calendly == true %}
     <script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>
   {% endif %}
-  {% if page.has_calendly_popup == true %}
-    <link rel="stylesheet" href="https://assets.calendly.com/assets/external/widget.css">
-  {% endif %}
   {%- feed_meta -%}
 
   <!-- tilt.dev typekit project -->


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/calendly:

cdd006c450df8b4a331cf36593517b1358b34eeb (2022-05-18 17:10:55 -0400)
docs: remove some calendly links that are rarely used

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics