### PR TITLE
site: tweak banner layout

### DIFF
--- a/src/_includes/announce-header.html
+++ b/src/_includes/announce-header.html
@@ -1,7 +1,7 @@
 <header class="newsHeader">
   <a class="newsHeader-inner" href="https://www.docker.com/blog/welcome-tilt-fixing-the-pains-of-microservice-development-for-kubernetes/">
     Big News!&nbsp;
-    <div style="font-weight: 700">Tilt is joining Docker</div>&nbsp;
+    <strong>Tilt is joining Docker</strong>
     {% svg assets/svg/moby.svg class="newsHeader-icon" %}
   </a>
 </header>

--- a/src/_sass/header.scss
+++ b/src/_sass/header.scss
@@ -1,44 +1,68 @@
 
 .newsHeader {
+  display: flex;
+  justify-content: center;  
   border-bottom: 2px dotted $tilt2-color-gray;
+  // Hack to make the banner full width:
   margin-left: $spacing-unit * -1;
   margin-right: $spacing-unit * -1;
+
+  @include mobileAndBelow {
+    margin-top: 100px; // Push so it's visible below .siteHeader-logoAndMenuButton
+    border-top: 2px dotted $tilt2-color-gray;
+  }
   
   .body--docs & {
+    justify-content: start;
     margin: 0;
   }
 }
 
 .newsHeader-inner {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  text-decoration: none;
-  transition: 300ms background-color ease;
-  font: inherit;
-  color: inherit;
-  font-size: 24px;
-  padding-top: $spacing-unit * 1.5;
-  padding-bottom: $spacing-unit * 1.5;
+  align-items: center;  
+  font-size: 18px;
+  padding-top: $spacing-unit;
+  padding-bottom: $spacing-unit;
+  @include reset-link-style;  
+
+  
+  @include mobileAndAbove {
+    font-size: 24px;
+    padding-top: $spacing-unit * 1.5;
+    padding-bottom: $spacing-unit * 1.5;
+  }
 
   .body--docs & {
-    justify-content: start;
     font-size: 18px;
     padding-top: $spacing-unit * 0.25;
     padding-bottom: $spacing-unit * 0.25;
     padding-left: $spacing-unit;
   }
+
+  strong {
+    transition: 300ms color ease;
+  }
 }
 
 .newsHeader-inner:hover {
-  background-color: $tilt2-color-gray-lightest;
+  strong {
+    color: $color-green;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
 }
 
 .newsHeader-icon {
-  height: 48px;
+  height: 36px;
+  margin-left: $spacing-unit * 0.25;
+
+  @include mobileAndAbove {
+    height: 45px;
+  }
   
   .body--docs & {
-    height: 44px;
+    height: 36px;
   }
 }
 
@@ -158,7 +182,7 @@
 
 .siteHeader2 {
   @include mobileAndBelow {
-    height: 100px; // Push initial content below mobile nav
+    height: 0; // This helps adjust space between newsHeader and content below
   }
 }
 
@@ -175,6 +199,7 @@
     position: fixed;
     left: 0;
     right: 0;
+    top: 0;
     background-color: $color-white;
     padding-left: $spacing-unit / 2;
     padding-right: $spacing-unit / 2;

--- a/src/_sass/tilt.scss
+++ b/src/_sass/tilt.scss
@@ -249,6 +249,11 @@ $tilt2-border-radius-large: 4px;
 
 // RESETS
 // --------------------------------------------------
+@mixin reset-link-style {
+  text-decoration: none;
+  color: inherit;
+}
+
 @mixin reset-button-style {
   font-family: inherit;
   font-size: inherit;


### PR DESCRIPTION
### 1. Made mobile layout more crisp
- Also, a minor tweak to the Docker icon size

| Before | After |
| --- | --- |
| <img width="410" alt="Screen Shot 2022-05-24 at 21 19 24" src="https://user-images.githubusercontent.com/20349/170158537-0de1fad2-7e38-4dd6-85e6-f8a06c19d7cc.png"> | <img width="410" alt="Screen Shot 2022-05-24 at 21 19 12" src="https://user-images.githubusercontent.com/20349/170158540-991bf70a-879d-471a-b96e-0e64766a4ef2.png"> | 

&nbsp;
### 2. Hover state is a bit more cheerful
| Before | After |
| --- | --- |
| <img width="748" alt="Screen Shot 2022-05-24 at 21 21 16" src="https://user-images.githubusercontent.com/20349/170158466-d9944292-6732-494e-aa4b-a692517ac995.png"> | <img width="713" alt="Screen Shot 2022-05-24 at 21 21 08" src="https://user-images.githubusercontent.com/20349/170158487-eae5c571-63dd-4532-9432-75dd1db71898.png">  | 

&nbsp;
### 3. Layout otherwise consistent
- Did a quick check for regressions
<img width="1728" alt="Screen Shot 2022-05-24 at 21 19 04" src="https://user-images.githubusercontent.com/20349/170158776-f620eaf6-f3cb-4a0d-911a-86e7d13cf8d1.png">
<img width="1728" alt="Screen Shot 2022-05-24 at 21 18 56" src="https://user-images.githubusercontent.com/20349/170158787-a06b0d0f-201f-47c0-ac2b-512ab607f0ec.png">
