### PR TITLE
fixing kubernetes link from install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,7 @@ macOS
 [Docker for Mac](https://docs.docker.com/docker-for-mac/install/) contains Docker, kubectl, and a Kubernetes cluster.
 
 - Install [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
-- In the preferences, click [Enable Kubernetes](https://docs.docker.com/docker-for-mac/#kubernetes)
+- In the preferences, click [Enable Kubernetes](https://docs.docker.com/desktop/kubernetes/)
 - Make Docker for Mac your local Kubernetes cluster:
 ```bash
 kubectl config use-context docker-desktop


### PR DESCRIPTION
the current link https://docs.docker.com/docker-for-mac/#kubernetes is not accurate because it seems like the get-started page has changed and doesn't have the kubernetes section anymore

<img width="1051" alt="Screenshot 2023-09-18 at 22 44 28" src="https://github.com/tilt-dev/tilt.build/assets/30873844/7d131102-a1c4-4761-9286-63d29dbfff5f">


doing some googling it seems that this (https://docs.docker.com/desktop/kubernetes/) is the correct page 