### PR TITLE
docs: update example java dockerfile

### DIFF
--- a/docs/example_java.md
+++ b/docs/example_java.md
@@ -242,7 +242,7 @@ local_resource(
 We've also updated our [Dockerfile](https://github.com/tilt-dev/tilt-example-java/blob/master/3-unpacked/Dockerfile):
 
 ```
-FROM openjdk:8-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR /app
 ADD BOOT-INF/lib /app/lib


### PR DESCRIPTION
the openjdk image is deprecated

most oss projects seem to be moving to eclipse-temurin,
including the official java guide:
https://docs.docker.com/language/java/build-images/
