### PR TITLE
docs: update 'GitHub' brand name

### DIFF
--- a/contributing-snippets.md
+++ b/contributing-snippets.md
@@ -2,7 +2,7 @@
 Would you like to help improve our Snippet Library?  
 Submitting a snippet is as straightfoward as submitting a Pull Request.
 
-0. Fork this repository on Github and then clone from your forked version of this repository
+0. Fork this repository on GitHub and then clone from your forked version of this repository
 
 1. Create a file in src/_data/snippets/*snippet_name*.yml
 
@@ -12,7 +12,7 @@ title: Descriptive Name of Your Snippet
 description: Explain what your snippet does
 code: |
   *Your code goes here*
-contributor: Your Github Handle (optional)
+contributor: Your GitHub Handle (optional)
 ```
 
 3. Commit your changes and [submit a Pull Request to the upstream repository of your fork (this one)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)

--- a/docs/disable_resources.md
+++ b/docs/disable_resources.md
@@ -93,4 +93,4 @@ config.clear_enabled_resources()
 Does this feature work for you? We want to reduce the cognitive load of finding and running the right resources. Please reach out:
 * Slack us from the [Kubernetes #tilt channel](http://slack.k8s.io)
 * Send an email to [hi@tilt.dev](mailto:hi@tilt.dev)
-* File an issue on [Github](https://github.com/tilt-dev/tilt/issues)
+* File an issue on [GitHub](https://github.com/tilt-dev/tilt/issues)

--- a/docs/multiple_repos.md
+++ b/docs/multiple_repos.md
@@ -65,7 +65,7 @@ include('./backend/Tiltfile')
 ## Loading Services Conditionally
 
 We have an example project with an auth service. Sometimes we want to run it
-with fake user data.  Sometimes we want to run it with real Github OAuth
+with fake user data.  Sometimes we want to run it with real GitHub OAuth
 login. Sometimes we want to run it with HTTPS instead of HTTP.
 
 The [`load_dynamic()`](api.html#api.load_dynamic) function doesn't have the nice
@@ -75,7 +75,7 @@ load services.
 Here's [an
 example](https://github.com/tilt-dev/ephemerator/blob/3f4c3c7d045f1f012ad70afe3907c83b5645d565/ephconfig/Tiltfile)
 that uses `os.path.exists` to see if you have OAuth client secrets or localhost
-HTTPS certificates. If you do, it uses the real Github OAuth login
+HTTPS certificates. If you do, it uses the real GitHub OAuth login
 server. Otherwise, it uses fake user data.
 
 ```python


### PR DESCRIPTION
It's a common mistake: The actual brand is "Git**H**ub" as opposed to "Git**h**ub".

There was references in `/blog/_posts/*` too, but I thought they were water under the bridge and no point in changing them, but happy to apply to them as well if needed.