### PR TITLE
docs: fix 'no-op' term

### DIFF
--- a/docs/disable_resources.md
+++ b/docs/disable_resources.md
@@ -35,7 +35,7 @@ To edit the args, you can run `tilt args` with a new set of arguments that will 
 $ tilt args bounding-box muxer max-object-detector
 ```
 
-> 💡 Note: if your args don't change between edits, Tilt will consider that a no-opt, even if you've enabled or disabled a different set of resources through the UI.
+> 💡 Note: if your args don't change between edits, Tilt will consider that a no-op, even if you've enabled or disabled a different set of resources through the UI.
 
 ### With the Tilt UI
 


### PR DESCRIPTION
This seems to be referring to [Wikipedia: NOP](https://en.wikipedia.org/wiki/NOP_(code))

> In computer science, a NOP, **no-op**, or NOOP (pronounced "no op"; short for no operation) is a machine language instruction and its assembly language mnemonic, programming language statement, or computer protocol **command that does nothing**.