### PR TITLE
docs: use inline code for 'snack'

### DIFF
--- a/docs/manual_update_control.md
+++ b/docs/manual_update_control.md
@@ -47,7 +47,7 @@ k8s_resource('bar', trigger_mode=TRIGGER_MODE_AUTO)
  <img src="assets/img/update-control.gif">
 </div>
 
-When you make changes to "snack", instead of them being automatically applied, Tilt will simply indicate unapplied changes by the asterisk to the right of `snack` in the sidebar. It will not automatically apply those changes. Instead, it will wait until you click the apply button to the left of `snack`.
+When you make changes to `snack`, instead of them being automatically applied, Tilt will simply indicate unapplied changes by the asterisk to the right of `snack` in the sidebar. It will not automatically apply those changes. Instead, it will wait until you click the apply button to the left of `snack`.
 
 ## Auto Init
 TriggerMode can be combined with the `auto_init` argument on [`k8s_resource()`](/api.html#api.k8s_resource), [`local_resource()`](/api.html#api.local_resource), and [`dc_resource()`](/api.html#api.dc_resource) for even more fine-grained control.


### PR DESCRIPTION
It's referenced via inline code block in two places in the same paragraph. This one is inconsistent.

![image](https://github.com/user-attachments/assets/0ffb81d3-f6e5-4d93-ac95-74d9905679a4)
