### PR TITLE
docs: add docs on emacs support

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -18,3 +18,45 @@ It provides syntax highlighting, autocomplete and signature support for `Tiltfil
 
 ## TextMate bundles
 The [tiltfile.tmbundle](https://github.com/tilt-dev/tiltfile.tmbundle) offers syntax highlighting for any IDEs supporting TextMate bundles, like IntelliJ GoLand, PyCharm or WebStorm.
+
+## Emacs
+
+Tilt is compatible with Emacs' `lsp-mode`.
+
+To enable it, install `lsp-mode` and add the following to your `.emacs`:
+
+```
+(require 'python-mode)
+
+(define-derived-mode tiltfile-mode
+  python-mode "tiltfile"
+  "Major mode for Tilt Dev."
+  (setq-local case-fold-search nil))
+
+(add-to-list 'auto-mode-alist '("Tiltfile$" . tiltfile-mode))
+
+(with-eval-after-load 'lsp-mode
+  (add-to-list 'lsp-language-id-configuration
+    '(tiltfile-mode . "tiltfile"))
+
+  (lsp-register-client
+    (make-lsp-client :new-connection (lsp-stdio-connection `("tilt" "lsp" "start"))
+                     :activation-fn (lsp-activate-on "tiltfile")
+                     :server-id 'tilt-lsp)))
+```
+
+## Other editors
+
+Tilt embeds its own language server based on Tree Sitter.
+
+https://github.com/tilt-dev/starlark-lsp
+
+To run it locally, run:
+
+```
+tilt lsp start
+```
+
+Adding Tiltfile support to a new editor usually requires
+a few lines of config to start the language server and connect.
+


### PR DESCRIPTION
Signed-off-by: Nick Santos <nick.santos@docker.com>
