### PR TITLE
deploy: tweak deploy triggers

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,10 +25,12 @@ jobs:
           filters: |
             blog:
               - 'blog/**'
+              - 'src/**'
               - '.github/**'
               - 'base/**'
             docs:
               - 'docs/**'
+              - 'src/**'
               - '.github/**'
               - 'base/**'
             site:


### PR DESCRIPTION
always deploy blog and docs when src
changes, because src contains the base
templates

Signed-off-by: Nick Santos <nick.santos@docker.com>
